### PR TITLE
Enhance the experience on macOS + better formatting & comments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ package-lock.json
 .gitignore
 .vscode
 azure-pipelines.yml
+.DS_Store

--- a/src/components/css/main.css
+++ b/src/components/css/main.css
@@ -11,8 +11,6 @@
   -webkit-app-region: drag;
 }
 
-
-
 body {
   font-family: Inter, sans-serif;
 

--- a/src/components/js/renderer.js
+++ b/src/components/js/renderer.js
@@ -1,18 +1,30 @@
 const ipc = require("electron").ipcRenderer;
 
-// close app
+// Function for closing the app using Electron's ipcMain.
 function closeApp(e) {
   e.preventDefault();
   ipc.send("close");
 }
 
-document.getElementById("closeBtn").addEventListener("click", closeApp);
-
+// Function for minimizing the app using Electron's ipcMain.
 function minimizeApp(e) {
   e.preventDefault();
   ipc.send("minimize");
 }
 
-document.getElementById("minBtn").addEventListener("click", minimizeApp);
+// If the platform is macOS, we want to get rid of the window controls
+// in favor of the traffic lights, thus expanding the drag region and moving the title.
+if (process.platform == "darwin") {
+  document.getElementById("buttons").style.visibility = "hidden";
+  document.getElementById("drag").style.width = "100%";
+  document.getElementById("title").style.left = "85px";
+}
 
+// If the platform is non-macOS, however, we want to add a listener for window controls.
+if (process.platform !== "darwin") {
+  document.getElementById("closeBtn").addEventListener("click", closeApp);
+  document.getElementById("minBtn").addEventListener("click", minimizeApp);
+}
+
+// Add the is-loaded property to the main element.
 document.getElementById("main").classList.add("is-loaded");

--- a/src/index.html
+++ b/src/index.html
@@ -15,9 +15,9 @@
   </head>
 
   <body>
-    <div class="drag"></div>
+    <div class="drag" id="drag"></div>
     <header>
-      <div class="buttons">
+      <div class="buttons" id="buttons">
         <button id="minBtn" href="" class="btn">
           <img src="./components/images/minimize.svg" height="15px" />
         </button>
@@ -25,7 +25,7 @@
           <img src="./components/images/close.svg" height="16px" />
         </button>
       </div>
-      <div class="title">
+      <div class="title" id="title">
         <img src="./components/images/titlelogo.png" height="20px" class="titlelogo" />
         &nbsp; &nbsp;
         <p>AvdanOS Imager</p>

--- a/src/main.js
+++ b/src/main.js
@@ -27,7 +27,7 @@ function createWindow() {
   // Position the macOS traffic lights into a more natural position
   mainWindow.setTrafficLightPosition({ x: 18, y: 18 });
   
-  mainWindow.setTitle(require('./package.json').productName);
+  mainWindow.setTitle(require('../package.json').productName);
 
   mainWindow.loadFile("./src/index.html");
 

--- a/src/main.js
+++ b/src/main.js
@@ -24,9 +24,11 @@ function createWindow() {
     icon: "./src/components/images/icon.png",
   });
 
+  // Position the macOS traffic lights into a more natural position
+  mainWindow.setTrafficLightPosition({ x: 18, y: 18 });
+  
   mainWindow.loadFile("./src/index.html");
-  // Open the DevTools.
-  // mainWindow.webContents.openDevTools()
+
   return mainWindow;
 }
 
@@ -36,14 +38,13 @@ function createWindow() {
 // initialization and is ready to create browser windows.
 // Some APIs can only be used after this event occurs.
 app.whenReady().then(() => {
-  const bigasswindow = createWindow();
+  const imagerWindow = createWindow();
   ipcMain.on("close", () => {
     app.quit();
   });
   ipcMain.on("minimize", () => {
-    bigasswindow.minimize();
+    imagerWindow.minimize();
   });
-
 
   app.on("browser-window-focus", function () {
     /*globalShortcut.register("CommandOrControl+R", () => {
@@ -88,9 +89,8 @@ app.whenReady().then(() => {
   });
 });
 
-// Quit when all windows are closed, except on macOS. There, it's common
-// for applications and their menu bar to stay active until the user quits
-// explicitly with Cmd + Q.
+// We want the program to close when all windows are closed,
+// even on macOS, overriding the default behaviour.
 app.on("window-all-closed", function () {
-  if (process.platform !== "darwin") app.quit();
+  app.quit();
 });

--- a/src/main.js
+++ b/src/main.js
@@ -27,6 +27,8 @@ function createWindow() {
   // Position the macOS traffic lights into a more natural position
   mainWindow.setTrafficLightPosition({ x: 18, y: 18 });
   
+  mainWindow.setTitle(require('./package.json').productName);
+
   mainWindow.loadFile("./src/index.html");
 
   return mainWindow;


### PR DESCRIPTION
should be self-explanatory thanks to the title, but short summary:
- hid the window controls on macOS
- moved the traffic lights into a more natural position
- moved the title in favor of traffic lights and expanded the drag region on macOS
- severely better formatting and comments especially in renderer.js