### PR TITLE
Fix CMake failing to generate build files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.10)
-project(Imager VERSION 1.0.0 LANGUAGES C)
+project(Imager VERSION 1.0.0 LANGUAGES C CXX)
 
 # Set C standard
 set(CMAKE_C_STANDARD 99)
@@ -63,7 +63,7 @@ if(MSVC)
     set_target_properties(imager-gui PROPERTIES WIN32_EXECUTABLE TRUE)
 else()
     target_compile_options(imager-gui PRIVATE -O2 -Wall)
-    target_link_libraries(imager-gui pthread m dl)
+    target_link_libraries(imager-gui PRIVATE pthread m dl)
 endif()
 
 # Install target


### PR DESCRIPTION
When trying to build locally on my machine (Fedora 43 Linux laptop), the CMake fails to generate files due to 2 different errors in `CMakeFile.txt` which are:

1. `CMake Error at CMakeLists.txt:66 (target_link_libraries)`

This is part of `cmake ..`'s output, just before exiting (with some extra redundant info)
```
-- Which libraries should wxWidgets use?
    wxUSE_STL:        OFF      (use C++ STL classes)
    wxUSE_REGEX:      sys      (enable support for wxRegEx class)
    wxUSE_ZLIB:       sys      (use zlib for LZW compression)
    wxUSE_EXPAT:      builtin  (use expat for XML parsing)
    wxUSE_LIBJPEG:    sys      (use libjpeg (JPEG file format))
    wxUSE_LIBPNG:     sys      (use libpng (PNG image format))
    wxUSE_LIBTIFF:    sys      (use libtiff (TIFF file format))
    wxUSE_NANOSVG:    builtin  (use NanoSVG for rasterizing SVG)
    wxUSE_LIBLZMA:    OFF      (use liblzma for LZMA compression)
    wxUSE_LIBSDL:     ON       (use SDL for audio on Unix)
    wxUSE_LIBMSPACK:  OFF      (use libmspack (CHM help files loading))

-- Configured wxWidgets 3.2.4 for Linux-6.18.10-200.fc43.x86_64
    Min OS Version required at runtime:                Linux x86_64
    Which GUI toolkit should wxWidgets use?            gtk3 3.24.51 with support for: GTK+ printing
    Should wxWidgets be compiled into single library?  OFF
    Should wxWidgets be linked as a shared library?    OFF
    Should wxWidgets support Unicode?                  ON
    What wxWidgets compatibility level should be used? 3.0
CMake Error at CMakeLists.txt:66 (target_link_libraries):
  The keyword signature for target_link_libraries has already been used with
  the target "imager-gui".  All uses of target_link_libraries with a target
  must be either all-keyword or all-plain.

  The uses of the keyword signature are here:

   * CMakeLists.txt:58 (target_link_libraries)
```

This one can be fixed by adding `PRIVATE` (`PUBLIC` or `INTERFACE` are also fine ig) in `target_link_libraries()` in line 66.

2. `CMAKE_CXX_COMPILE_OBJECT` and `CMAKE_CXX_LINK_EXECUTABLE` variables were missing

Here's a second `cmake ..` output (ignoring the duplicated wxWidget's config info as above):
```
-- Configuring done (0.9s)
CMake Error: Error required internal CMake variable not set, cmake may not be built correctly.
Missing variable is:
CMAKE_CXX_COMPILE_OBJECT
CMake Error: Error required internal CMake variable not set, cmake may not be built correctly.
Missing variable is:
CMAKE_CXX_LINK_EXECUTABLE
-- Generating done (0.2s)
CMake Generate step failed.  Build files cannot be regenerated correctly.
```

Since this project has some `.cpp` source files, but `CXX` is not included as a language (while `C` is), this error will be thrown. Either by changing `LANGUAGES C CXX` inside `project()` in line 2 or removing `LANGUAGES C` in the same line will make this error dissapear.