### PR TITLE
Format detection, compressed images, Windows ISOs, and device locking

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,6 +50,7 @@ set(SOURCES
     src/core/image_reader.c
     src/core/image_write.c
     src/core/windows_iso.c
+    src/core/device_lock.c
 )
 
 # Create executable
@@ -93,6 +94,7 @@ set(GUI_SOURCES
     src/core/image_reader.c
     src/core/image_write.c
     src/core/windows_iso.c
+    src/core/device_lock.c
 )
 
 # Create GUI executable

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,16 +8,57 @@ set(CMAKE_C_STANDARD_REQUIRED ON)
 # Include directories
 include_directories(include)
 
+# Optional streaming decompression codecs
+set(DECOMP_LIBS "")
+set(DECOMP_DEFS "")
+set(DECOMP_INCLUDES "")
+find_package(ZLIB QUIET)
+if(ZLIB_FOUND)
+    list(APPEND DECOMP_LIBS ZLIB::ZLIB)
+    list(APPEND DECOMP_DEFS HAVE_ZLIB)
+endif()
+find_package(LibLZMA QUIET)
+if(LIBLZMA_FOUND)
+    list(APPEND DECOMP_LIBS LibLZMA::LibLZMA)
+    list(APPEND DECOMP_DEFS HAVE_LZMA)
+endif()
+find_package(BZip2 QUIET)
+if(BZIP2_FOUND)
+    list(APPEND DECOMP_LIBS BZip2::BZip2)
+    list(APPEND DECOMP_DEFS HAVE_BZIP2)
+endif()
+find_library(ZSTD_LIBRARY zstd)
+find_path(ZSTD_INCLUDE_DIR zstd.h)
+if(ZSTD_LIBRARY AND ZSTD_INCLUDE_DIR)
+    list(APPEND DECOMP_LIBS ${ZSTD_LIBRARY})
+    list(APPEND DECOMP_DEFS HAVE_ZSTD)
+    list(APPEND DECOMP_INCLUDES ${ZSTD_INCLUDE_DIR})
+endif()
+if(DECOMP_DEFS)
+    message(STATUS "Imager: streaming decompression enabled: ${DECOMP_DEFS}")
+else()
+    message(STATUS "Imager: no decompression codecs found; compressed images will be rejected")
+endif()
+
 # Source files
 set(SOURCES
     src/main.c
     src/core/progress.c
     src/utils/utils.c
     src/core/iso_operations.c
+    src/core/image_format.c
+    src/core/image_reader.c
+    src/core/image_write.c
+    src/core/windows_iso.c
 )
 
 # Create executable
 add_executable(imager ${SOURCES})
+target_compile_definitions(imager PRIVATE ${DECOMP_DEFS})
+target_link_libraries(imager PRIVATE ${DECOMP_LIBS})
+if(DECOMP_INCLUDES)
+    target_include_directories(imager PRIVATE ${DECOMP_INCLUDES})
+endif()
 
 # Set compiler flags
 if(MSVC)
@@ -48,11 +89,20 @@ set(GUI_SOURCES
     src/utils/utils.c
     src/utils/drive_list.c
     src/core/iso_operations.c
+    src/core/image_format.c
+    src/core/image_reader.c
+    src/core/image_write.c
+    src/core/windows_iso.c
 )
 
 # Create GUI executable
 add_executable(imager-gui ${GUI_SOURCES})
 target_include_directories(imager-gui PRIVATE include)
+target_compile_definitions(imager-gui PRIVATE ${DECOMP_DEFS})
+target_link_libraries(imager-gui PRIVATE ${DECOMP_LIBS})
+if(DECOMP_INCLUDES)
+    target_include_directories(imager-gui PRIVATE ${DECOMP_INCLUDES})
+endif()
 
 # Link wxWidgets
 target_link_libraries(imager-gui PRIVATE wx::core wx::base)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,35 +1,91 @@
-# Contributing Guidelines
+# Contributing
 
-## Basics 
+Thanks for taking an interest in the imager. This document explains how to
+get a change merged with a minimum of friction.
 
-To start your contribution, please follow the steps below:
+## Before you start
 
-1. Create a fork of this repo.
+For anything bigger than a typo fix or a small bug fix, please open an
+issue first and describe what you want to change and why. It saves both of
+us time if we agree on the approach before you write the code. Small,
+focused changes get reviewed quickly; thousand-line drive-by rewrites
+usually don't get reviewed at all.
 
-2. Git clone your fork to your machine:
+## Building
+
+See [docs/BUILD.md](docs/BUILD.md). The short version:
+
 ```sh
-git clone https://url.to.your/github/fork.git
+mkdir build && cd build
+cmake ..
+cmake --build .
 ```
 
-3. Use dev branch, commits targeting main will be ignored.
+The first build compiles wxWidgets and takes a few minutes. If you are only
+touching the CLI, `make` in the repository root is much faster.
+
+## Code style
+
+There is no formatter config yet, so match the surrounding code. In
+practice that means:
+
+- The core is C99. C++ is only used in `src/gui_main.cpp`. Don't introduce
+  C++ into `src/core/` or `src/utils/` otherwise I will personally find you and do bad stuff to you.
+- Four-space indentation, braces on the same line.
+- Every function that can fail returns `0` on success and `-1` on error,
+  and prints a useful message to stderr at the point of failure.
+- The core has no hard third-party dependencies. Decompression codecs are
+  optional and guarded by `HAVE_ZLIB`, `HAVE_LZMA`, `HAVE_BZIP2` and
+  `HAVE_ZSTD`; code must still compile when none of them are defined.
+- Platform-specific code lives behind `#if defined(_WIN32)` /
+  `#elif defined(__APPLE__)` / `#else` blocks, in that order. If you add a
+  platform path, make sure the other two still build.
+- Headers that are included from the GUI need `extern "C"` guards.
+
+## Testing your changes
+
+Do not test destructive changes against a disk you care about. On Linux, a
+loop device behaves like a real block device and costs nothing:
+
 ```sh
-git checkout -b dev remotes/upstream/dev
+truncate -s 2G /tmp/testdisk.img
+sudo losetup -fP /tmp/testdisk.img
+losetup -l                      # note the /dev/loopN it was assigned
+sudo ./imager something.iso /dev/loopN
 ```
 
-4. Make changes as you want.
+A cheap sacrificial USB stick is the next best thing, and the only way to
+test the Windows volume-locking path properly.
 
-5. Commit your changes:
-```sh
-git commit -m "brief explanation of the changes"
-```
+At a minimum, before opening a merge request:
 
-`Tip: You can setup code signing and add 0S to the commit command above to get a verified checkmark`
+- Build with CMake without warnings on your platform.
+- Flash a hybrid ISO and check that verification passes (I'll supply one later on, alongside making a CI/CD pipeline).
+- If you touched format detection or the streaming reader, also test one
+  compressed image and one plain `.img` file.
 
-6. Push your changes:
-```sh
-git push
-```
+## Submitting changes
 
-7. Create pull request on GitHub.
+1. Fork the repository and create a branch off the default branch.
+2. Keep each merge request to one topic. A bug fix and an unrelated
+   refactor should be two MRs.
+3. Write commit messages that explain *why*, not just *what*. First line
+   under 72 characters, imperative mood ("Fix off-by-one in GPT probe",
+   not "Fixed" or "Fixes").
+4. Open a merge request against the default branch. Direct pushes to the
+   default branch are not accepted.
+5. If review feedback comes in, push follow-up commits; don't force-push
+   over the discussion until the review is done.
 
-## No Direct Commits!
+## Reporting bugs
+
+A good bug report includes:
+
+- Your OS and version, and whether you used the CLI or the GUI.
+- The exact command you ran and its complete output.
+- What kind of image you were flashing (distro, whether it was
+  compressed, roughly how large).
+- The target device type (USB 2/3 stick, SD card via reader, etc.).
+
+"Verification failed" reports without the above are usually a dying USB
+stick, and there is not much we can do with them.

--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,23 @@
 CC=gcc
-CFLAGS=-O2 -Wall -I./include
+
+# Streaming decompression codecs. Remove entries here (and the matching
+# libraries below) if a library is unavailable on your system.
+# The CMake build auto-detects these instead.
+CODEC_DEFS=-DHAVE_ZLIB -DHAVE_LZMA -DHAVE_BZIP2 -DHAVE_ZSTD
+CODEC_LIBS=-lz -llzma -lbz2 -lzstd
+
+CFLAGS=-O2 -Wall -I./include $(CODEC_DEFS)
 TARGET=imager
-SRCS=src/main.c src/core/progress.c src/utils/utils.c src/core/iso_operations.c
+SRCS=src/main.c src/core/progress.c src/utils/utils.c src/core/iso_operations.c src/core/image_format.c src/core/image_reader.c src/core/image_write.c src/core/windows_iso.c
 OBJS=$(SRCS:.c=.o)
 
 all: $(TARGET)
 
 $(TARGET): $(OBJS)
-	$(CC) $(OBJS) -o $(TARGET)
+	$(CC) $(OBJS) -o $(TARGET) $(CODEC_LIBS)
 
 %.o: %.c
 	$(CC) $(CFLAGS) -c $< -o $@
 
 clean:
-	rm -f $(OBJS) $(TARGET) 
+	rm -f $(OBJS) $(TARGET)

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ CODEC_LIBS=-lz -llzma -lbz2 -lzstd
 
 CFLAGS=-O2 -Wall -I./include $(CODEC_DEFS)
 TARGET=imager
-SRCS=src/main.c src/core/progress.c src/utils/utils.c src/core/iso_operations.c src/core/image_format.c src/core/image_reader.c src/core/image_write.c src/core/windows_iso.c
+SRCS=src/main.c src/core/progress.c src/utils/utils.c src/core/iso_operations.c src/core/image_format.c src/core/image_reader.c src/core/image_write.c src/core/windows_iso.c src/core/device_lock.c
 OBJS=$(SRCS:.c=.o)
 
 all: $(TARGET)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # AvdanOS Imager
 
-This is a Balena Etcher alternative written in C and C++.
+A small, fast tool for writing OS images to USB drives. Think of it as a
+no-nonsense alternative to Balena Etcher or Rufus. Plain C for the core, a native
+wxWidgets front end instead of a bundled browser engine, and no telemetry.
+
+Runs on Linux, macOS and Windows.
 
 ## To-Do List:
 
@@ -18,93 +22,94 @@ Legend:
 
 `🚧` Cross-Platform GUI Framework (wxWidgets)
 
-## Current Status
+## Features
 
-The project now supports both a **working CLI** and a **native C++ GUI**:
+- Raw image writing with a mandatory bit-for-bit verification pass.
+- Knows what it is flashing. Hybrid ISOs, plain ISO9660, UDF and raw
+  MBR/GPT disk images are detected and validated before a single byte is
+  written. Non-bootable combinations produce a warning up front, not a
+  dead USB stick twenty minutes later.
+- Flashes compressed images (`.gz`, `.xz`, `.bz2`, `.zst`) directly.
+  Decompression happens on the fly; no temp files, no manual unpacking.
+- Extraction mode for Windows install ISOs (`--extract`): partitions the
+  drive, formats FAT32, copies the files and splits `install.wim` when it
+  exceeds the FAT32 4 GiB limit.
+- Unmounts and locks the target device before writing, so a mounted
+  filesystem can't corrupt the write halfway through.
+- Two front ends: `imager` for the terminal, `imager-gui` for everyone else.
 
-### CLI Features:
-- ✅ ISO to USB writing
-- ✅ Progress tracking
-- ✅ Write verification (Bit-for-bit)
-- ✅ Cross-platform support (Linux, macOS, and Windows)
+## Building
 
-### GUI Features (Initial Implementation):
-- ✅ **Native Windows Vibe**: Uses wxWidgets for a Rufus-like aesthetic.
-- ✅ **Automated Drive Selection**: Lists friendly drive names and capacities.
-- ✅ **Write Verification**: Integrated bit-for-bit verification after flashing.
-- ✅ **Safety Filtering**: Filters out internal drives by default to prevent data loss.
-- ✅ **High-Capacity Support**: Correctly handles drives larger than 500GB.
-- ✅ **Multi-threaded**: UI remains responsive during flashing and verification.
+You need a C/C++ compiler and CMake 3.10 or newer. The optional
+decompression codecs (zlib, liblzma, bzip2, zstd) are picked up
+automatically if the development packages are installed.
 
-> [!NOTE]
-> The current GUI is an initial functional implementation. The final design and layout are subject to further refinement.
-
-## Project Structure
-
-```
-├── include/imager/
-│   ├── progress.h
-│   ├── utils.h
-│   ├── drive_list.h
-│   ├── iso_operations.h
-│   └── imager.h
-├── src/
-│   ├── core/
-│   │   ├── progress.c
-│   │   └── iso_operations.c
-│   ├── utils/
-│   │   ├── utils.c
-│   │   └── drive_list.c
-│   ├── main.c        (CLI Entry)
-│   └── gui_main.cpp  (GUI Entry)
-├── docs/
-│   ├── BUILD.md
-│   └── USAGE.md
-├── Makefile
-├── CMakeLists.txt
-└── README.md
-```
-
-## Getting Started
-
-### Prerequisites
-- **GCC compiler** (MinGW-w64 for Windows) or **MSVC** (Visual Studio).
-- **CMake 3.10+**.
-- **wxWidgets 3.2+** (Automatically downloaded via CMake).
-
-### Build (CMake - Recommended)
-```bash
+```sh
 mkdir build && cd build
 cmake ..
 cmake --build .
 ```
-This will generate two executables:
-- `imager`: The command-line version.
-- `imager-gui`: The native graphical version.
 
-### Usage (GUI)
-Simply run `imager-gui` as Administrator/Root, select your ISO, and choose your target USB drive from the dropdown.
+This produces both `imager` and `imager-gui`. wxWidgets is downloaded and
+built automatically for the GUI, so the first build takes a while. See
+[docs/BUILD.md](docs/BUILD.md) for per-platform details and the
+Makefile-only CLI build.
 
-### Usage (CLI)
-```bash
-# Linux/macOS
-sudo ./imager <iso_file> <usb_device>
+## Usage
 
-# Windows (Run as Administrator)
-.\imager.exe <iso_file> \\.\PhysicalDriveX
+Writing an image needs raw device access, so run as root (or from an
+Administrator shell on Windows):
+
+```sh
+# Linux
+sudo ./imager fedora.iso /dev/sdb
+
+# macOS
+sudo ./imager archlinux.img.xz /dev/disk4
+
+# Windows (Administrator)
+imager.exe ubuntu.iso \\.\PhysicalDrive2
 ```
 
-## Safety
-- **You must run as root/admin to access raw devices.**
-- **All data on the target device will be destroyed!**
-- Double-check your device selection before clicking START.
-- The app filters out internal drives by default for safety.
+Compressed images are handled transparently. For Windows install ISOs,
+use extraction mode instead of a raw write:
 
-## Documentation
-- **[BUILD.md](docs/BUILD.md)** - Detailed build instructions
-- **[USAGE.md](docs/USAGE.md)** - Complete usage guide and troubleshooting
+```sh
+sudo ./imager --extract Win11.iso /dev/sdb
+```
+
+Or launch `imager-gui`, pick the image and the drive, and press START.
+The GUI shows the detected format before you commit to anything.
+
+The full guide, including how to find your device path and what every
+warning means, is in [docs/USAGE.md](docs/USAGE.md).
+
+## Safety
+
+Writing an image destroys everything on the target drive. There is no
+undo. The imager tries hard to protect you - it filters out internal
+disks in the GUI by default, asks for confirmation, and refuses to write
+while the device is in use - but the last line of defense is you reading
+the device path twice.
+
+## Project layout
+
+```
+include/imager/     public headers
+src/core/           format detection, streaming reader, write/verify,
+                    extraction mode, device locking, progress
+src/utils/          drive enumeration, CLI helpers
+src/main.c          CLI entry point
+src/gui_main.cpp    wxWidgets GUI
+docs/               build and usage documentation
+```
+
+## Contributing
+
+Bug reports and merge requests are welcome. Please read
+[CONTRIBUTING.md](CONTRIBUTING.md) first, especially the part about
+testing against loop devices instead of your own SSD.
 
 ## License
-GPLv3
 
-
+GPLv3. See [LICENSE](LICENSE).

--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -1,50 +1,111 @@
-# Building AvdanOS Imager
+# Building
 
-## Overview
+The project builds two binaries: `imager` (CLI) and `imager-gui`
+(wxWidgets GUI). CMake is the primary build system; a plain Makefile is
+kept around for quick CLI-only builds on Unix.
 
-This project supports both a CLI and a GUI version across Linux, macOS, and Windows.
+## Dependencies
 
-## Prerequisites
+Required:
 
-- **GCC compiler** (MinGW-w64 for Windows) or **MSVC** (Visual Studio).
-- **CMake 3.10+**.
-- **wxWidgets 3.2+** (automatically downloaded via CMake for the GUI version).
+- A C/C++ compiler: GCC, Clang, MSVC, or MinGW-w64
+- CMake 3.10 or newer
 
-## Build Methods
+Optional, for flashing compressed images. CMake detects whichever of these
+are installed and enables the matching codec; missing ones are simply
+skipped and the imager will tell the user to decompress such files
+manually:
 
-### Using CMake (Recommended for All Platforms)
+- zlib (`.gz`)
+- liblzma / xz-utils (`.xz`)
+- bzip2 (`.bz2`)
+- zstd (`.zst`)
+
+wxWidgets 3.2 is downloaded and built automatically by CMake; you do not
+need to install it. This makes the first configure + build take several
+minutes. Subsequent builds are fast.
+
+### Debian / Ubuntu
+
+```sh
+sudo apt install build-essential cmake \
+    zlib1g-dev liblzma-dev libbz2-dev libzstd-dev \
+    libgtk-3-dev
+```
+
+`libgtk-3-dev` is only needed for the GUI.
+
+### Fedora
+
+```sh
+sudo dnf install gcc gcc-c++ cmake \
+    zlib-devel xz-devel bzip2-devel libzstd-devel \
+    gtk3-devel
+```
+
+### macOS
+
+```sh
+xcode-select --install
+brew install cmake xz zstd
+```
+
+zlib and bzip2 ship with the system.
+
+### Windows
+
+Install Visual Studio (with the "Desktop development with C++" workload)
+or MinGW-w64, plus CMake. The codec libraries are optional; the easiest
+way to get them is vcpkg:
 
 ```powershell
-mkdir build
-cd build
+vcpkg install zlib liblzma bzip2 zstd
+cmake .. -DCMAKE_TOOLCHAIN_FILE=<vcpkg>/scripts/buildsystems/vcpkg.cmake
+```
+
+Without them the imager builds fine but rejects compressed images.
+
+## Building with CMake
+
+```sh
+mkdir build && cd build
 cmake ..
 cmake --build .
 ```
 
-This will create:
-- `imager`: The command-line version.
-- `imager-gui`: The graphical user interface version.
+The configure step prints which codecs were found:
 
-### Using Makefile (Linux/macOS CLI Only)
+```
+-- Imager: streaming decompression enabled: HAVE_ZLIB;HAVE_LZMA;HAVE_BZIP2;HAVE_ZSTD
+```
 
-```bash
+For a debug build:
+
+```sh
+cmake -DCMAKE_BUILD_TYPE=Debug ..
+```
+
+On Windows you can also open the folder directly in Visual Studio, which
+drives CMake for you.
+
+## Building with the Makefile (CLI only, Unix)
+
+```sh
 make
 ```
 
-## Platform-Specific Notes
+The Makefile assumes all four codec libraries are installed. If one is
+missing on your system, remove its `-DHAVE_*` flag from `CODEC_DEFS` and
+the matching `-l` flag from `CODEC_LIBS` at the top of the Makefile.
 
-### Windows
-If using Visual Studio, you can open the project folder directly or use the CMake GUI to generate a `.sln` file.
+## Installing
 
-### Linux
-Ensure you have the development headers for your graphics drivers (Mesa) and X11/Wayland if building the GUI.
+```sh
+cmake --install build        # installs imager and imager-gui to bin/
+```
 
-## Development
+or simply copy the binaries somewhere on your PATH:
 
-```bash
-# Debug build (with CMake)
-mkdir build-debug
-cd build-debug
-cmake -DCMAKE_BUILD_TYPE=Debug ..
-cmake --build .
+```sh
+sudo cp build/imager /usr/local/bin/
 ```

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -1,97 +1,136 @@
-# AvdanOS Imager Usage Guide
+# Usage
 
-## Overview
+## Synopsis
 
-AvdanOS Imager writes ISO images to USB devices. It includes:
-- **CLI version (`imager`)**: For fast, command-line usage.
-- **GUI version (`imager-gui`)**: For a user-friendly drag-and-drop experience.
-
-## Basic Usage (CLI)
-
-### Linux/macOS
-```bash
-sudo ./imager <iso_file> <usb_device>
+```
+imager [--extract] <image> <device>
 ```
 
-### Windows (Administrator)
+Writing to a raw device requires elevated privileges: use `sudo` on Linux
+and macOS, or an Administrator shell on Windows.
+
+## Supported images
+
+| Type | Example | Behavior |
+|------|---------|----------|
+| Hybrid ISO (ISO9660 + MBR/GPT) | most Linux distros | written raw, boots BIOS/UEFI |
+| Raw disk image (MBR or GPT) | `.img` files, Raspberry Pi images | written raw |
+| Compressed image | `foo.iso.gz`, `bar.img.xz`, `.bz2`, `.zst` | decompressed on the fly while writing |
+| Plain ISO9660 (no partition table) | some old or exotic ISOs | written raw with a warning; may not boot everywhere |
+| Windows install ISO (UDF) | `Win11.iso` | use `--extract`; a raw write will not boot |
+
+The imager identifies the file by its contents, not its extension, and
+prints what it found before asking for confirmation:
+
+```
+Image: fedora.iso
+Detected format: Hybrid ISO (ISO9660 + MBR/GPT)
+Volume label:    Fedora-WS-Live
+Bootable:        yes (El Torito)
+```
+
+## What a flash actually does
+
+1. Analyzes the image and warns about anything that won't boot.
+2. Asks you to confirm the target device.
+3. Unmounts every filesystem on the device and takes an exclusive lock,
+   so nothing else can touch it mid-write. If another program is using
+   the drive, the imager aborts here instead of corrupting the write.
+4. Writes the image (decompressing on the fly if needed).
+5. Reads everything back and compares it bit for bit against the source.
+
+There is no way to skip the verification pass, and that is intentional:
+USB sticks lie.
+
+## Windows install ISOs (--extract)
+
+Windows ISOs are not hybrid images, so writing them raw produces a stick
+that won't boot. Extraction mode does what tools like Rufus do instead:
+
+```sh
+sudo ./imager --extract Win11.iso /dev/sdb
+```
+
+This partitions the drive (MBR), formats a FAT32 partition, copies the
+ISO contents file by file, and, when `sources/install.wim` is larger than
+FAT32 allows (4 GiB), splits it into `.swm` parts that Windows Setup
+understands.
+
+Extraction mode relies on standard platform tools being present:
+
+- Linux: `parted`, `mkfs.vfat`, `mount`, `tar`; `wimlib-imagex` (package
+  `wimtools`) if the wim needs splitting
+- macOS: `hdiutil`, `diskutil`, `tar`; `wimlib` from Homebrew for splitting
+- Windows: `diskpart`, PowerShell, `robocopy`, `dism` (all ship with
+  Windows)
+
+Known limitations: the resulting stick boots on UEFI systems only, and on
+Windows the OS cannot format FAT32 partitions larger than 32 GB.
+
+## Finding your device
+
+Linux:
+
+```sh
+lsblk -d -o NAME,SIZE,MODEL,TRAN
+```
+
+macOS:
+
+```sh
+diskutil list external
+```
+
+Windows (Administrator PowerShell):
+
 ```powershell
-.\imager.exe <iso_file> \\.\PhysicalDriveX
+Get-Disk
 ```
 
-## GUI Usage
+| OS | Device path format |
+|----|--------------------|
+| Linux | `/dev/sdb`, `/dev/nvme1n1` (the whole disk, not `/dev/sdb1`) |
+| macOS | `/dev/disk4` |
+| Windows | `\\.\PhysicalDrive2` |
 
-1. Launch `imager-gui`.
-2. Drag and drop your `.iso` file onto the window.
-3. Enter the target device path.
-4. Click **FLASH!**.
+Always pass the whole disk, never a partition.
 
-## Finding Your USB Device
+## GUI
 
-### Windows
-Run `wmic diskdrive list brief` or use **Disk Management** to find the `PhysicalDrive` number.
-
-### Linux
-```bash
-lsblk
-```
-
-### macOS
-```bash
-diskutil list
-```
-
-## Device Paths
-
-| OS | Example Path |
-|----|--------------|
-| Windows | `\\.\PhysicalDrive1` |
-| Linux | `/dev/sdX` |
-| macOS | `/dev/diskN` |
-
-## Safety Warnings
-
-⚠️ **IMPORTANT**: This tool will **completely erase** all data on the target device!
-
-- Always double-check the device path.
-- Ensure you have backups.
-- Run as Administrator/Root.
+Run `imager-gui` as root/Administrator. It lists removable drives by
+name and capacity (internal disks are hidden unless you untick "List USB
+drives only"), shows the detected image format and volume label as soon
+as you pick a file, and offers a "Windows extraction mode" checkbox that
+it pre-selects when it detects Windows install media. Progress and
+verification behave exactly like the CLI.
 
 ## Troubleshooting
 
-### Permission Denied
-Ensure you are running the terminal (or the GUI app) as **Administrator** (Windows) or using **sudo** (Linux/macOS).
-```bash
-sudo ./imager ubuntu.iso /dev/sdX
-```
+**"Permission denied" / "Error opening device"** - you are not root (or
+not an Administrator). Elevate and retry.
 
-### Device Not Found
-- Ensure the USB device is properly connected.
-- Check if the device is mounted; some OSs block raw access to mounted drives.
-- On Windows, ensure you used the `\\.\PhysicalDriveX` format or use the dropdown in the GUI.
+**"Could not unmount/lock device"** - something is using the drive: a
+file manager window, a terminal with its working directory on the stick,
+an indexer, another imaging tool. Close it and retry. On Windows,
+Explorer windows showing the drive are the usual culprit.
 
-### Verification Failed
-- Try writing again.
-- Check if the USB device has sufficient space.
-- Ensure the device is not defective. Both the CLI and GUI always perform a verification pass after writing.
+**"This build has no ... support compiled in"** - the image is compressed
+with a codec that wasn't available when the imager was built. Either
+decompress the file manually (`xz -d`, `gunzip`, ...) or rebuild with the
+codec's development package installed; see
+[BUILD.md](BUILD.md).
 
-## Advanced Usage
+**"Verification failed"** - the data read back from the stick doesn't
+match the image. Retry once; if it fails again the stick is almost
+certainly counterfeit or worn out. Cheap high-capacity sticks that fail
+exactly at the same percentage every time are reporting more capacity
+than they physically have.
 
-### Building from Source
-See [BUILD.md](BUILD.md) for build instructions.
+**Warning about a plain ISO9660 / UDF image** - the image has no
+partition table, so a raw write may not produce a bootable drive. For
+Windows ISOs, use `--extract`. For anything else, check whether the
+vendor provides a `.img` or hybrid ISO variant.
 
-### Installation (Linux/macOS)
-```bash
-sudo cp imager /usr/local/bin/
-```
-
-Then use from anywhere:
-```bash
-sudo imager ubuntu.iso /dev/sdX
-```
-
-## Future GUI Features
-
-While the initial GUI is functional, I plan to add:
-- Automated `.iso` downloading.
-- Advanced partitioning options.
-- User-friendly interface similar to Balena Etcher.
+**The drive "shrank" after flashing** - normal. The OS only sees the
+partitions defined by the image. Repartition and reformat the stick to
+get the full capacity back.

--- a/include/imager/device_lock.h
+++ b/include/imager/device_lock.h
@@ -1,0 +1,21 @@
+#ifndef DEVICE_LOCK_H
+#define DEVICE_LOCK_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct device_lock device_lock_t;
+
+#define DEVICE_LOCK_UNMOUNT_ONLY 0
+#define DEVICE_LOCK_EXCLUSIVE    1
+
+device_lock_t *device_lock_acquire(const char *dev_path, int exclusive);
+
+void device_lock_release(device_lock_t *lock);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/include/imager/image_format.h
+++ b/include/imager/image_format.h
@@ -1,0 +1,41 @@
+#ifndef IMAGE_FORMAT_H
+#define IMAGE_FORMAT_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef enum {
+    IMG_FORMAT_UNKNOWN = 0,
+    IMG_FORMAT_ISO9660,
+    IMG_FORMAT_ISO_HYBRID,
+    IMG_FORMAT_UDF,
+    IMG_FORMAT_RAW_MBR,
+    IMG_FORMAT_RAW_GPT,
+    IMG_FORMAT_COMPRESSED_GZ,
+    IMG_FORMAT_COMPRESSED_XZ,
+    IMG_FORMAT_COMPRESSED_BZ2,
+    IMG_FORMAT_COMPRESSED_ZSTD
+} image_format_t;
+
+typedef struct {
+    image_format_t format;
+    int has_mbr;
+    int has_gpt;
+    int has_iso9660;
+    int has_udf;
+    int has_el_torito;
+    char volume_label[33];
+    char description[160];
+} image_info_t;
+
+
+int detect_image_format(const char *path, image_info_t *info);
+const char *image_format_name(image_format_t fmt);
+int image_format_is_raw_writable(const image_info_t *info);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/include/imager/image_reader.h
+++ b/include/imager/image_reader.h
@@ -1,0 +1,32 @@
+#ifndef IMAGE_READER_H
+#define IMAGE_READER_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <sys/types.h>
+#include <stddef.h>
+#include "imager/image_format.h"
+
+typedef struct image_reader image_reader_t;
+
+image_reader_t *image_reader_open(const char *path, image_format_t format);
+
+long image_reader_read(image_reader_t *r, void *buf, size_t len);
+
+off_t image_reader_input_pos(const image_reader_t *r);
+
+off_t image_reader_input_size(const image_reader_t *r);
+
+int image_reader_is_compressed(const image_reader_t *r);
+
+void image_reader_close(image_reader_t *r);
+
+int image_reader_format_supported(image_format_t fmt);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/include/imager/image_write.h
+++ b/include/imager/image_write.h
@@ -1,0 +1,24 @@
+#ifndef IMAGE_WRITE_H
+#define IMAGE_WRITE_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <sys/types.h>
+#include "imager/image_format.h"
+#include "imager/progress.h"
+
+int write_image_to_device(const char *image_path, image_format_t format,
+                          const char *dev_path, progress_callback_t cb,
+                          off_t *bytes_written);
+
+int verify_device_against_image(const char *image_path, image_format_t format,
+                                const char *dev_path, off_t total_bytes,
+                                progress_callback_t cb);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/include/imager/windows_iso.h
+++ b/include/imager/windows_iso.h
@@ -1,0 +1,17 @@
+#ifndef WINDOWS_ISO_H
+#define WINDOWS_ISO_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "imager/progress.h"
+
+int write_iso_extracted(const char *iso_path, const char *dev_path,
+                        progress_callback_t cb);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/core/device_lock.c
+++ b/src/core/device_lock.c
@@ -1,0 +1,226 @@
+#if !defined(_WIN32)
+#define _DEFAULT_SOURCE
+#endif
+
+#include "imager/device_lock.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <ctype.h>
+#include <errno.h>
+
+#ifdef _WIN32
+#include <windows.h>
+#include <winioctl.h>
+#else
+#include <unistd.h>
+#include <fcntl.h>
+#endif
+
+#if defined(_WIN32)
+
+#define MAX_LOCKED_VOLUMES 26
+
+struct device_lock {
+    HANDLE volumes[MAX_LOCKED_VOLUMES];
+    int count;
+};
+
+static int parse_disk_number(const char *dev_path) {
+    size_t n = strlen(dev_path);
+    size_t d = n;
+    while (d > 0 && isdigit((unsigned char)dev_path[d - 1])) d--;
+    if (d == n) return -1;
+    return atoi(dev_path + d);
+}
+
+static int volume_on_disk(HANDLE h, int disk) {
+    unsigned char buf[sizeof(VOLUME_DISK_EXTENTS) + 8 * sizeof(DISK_EXTENT)];
+    VOLUME_DISK_EXTENTS *ext = (VOLUME_DISK_EXTENTS *)buf;
+    DWORD ret = 0;
+    DWORD i;
+
+    if (!DeviceIoControl(h, IOCTL_VOLUME_GET_VOLUME_DISK_EXTENTS,
+                         NULL, 0, buf, sizeof(buf), &ret, NULL)) {
+        return 0;
+    }
+    for (i = 0; i < ext->NumberOfDiskExtents; i++) {
+        if ((int)ext->Extents[i].DiskNumber == disk) return 1;
+    }
+    return 0;
+}
+
+device_lock_t *device_lock_acquire(const char *dev_path, int exclusive) {
+    int disk = parse_disk_number(dev_path);
+    device_lock_t *lock;
+    char letter;
+
+    if (disk < 0 || strstr(dev_path, "PhysicalDrive") == NULL) {
+        fprintf(stderr, "Error: expected a device like \\\\.\\PhysicalDriveN\n");
+        return NULL;
+    }
+
+    lock = (device_lock_t *)calloc(1, sizeof(*lock));
+    if (lock == NULL) {
+        perror("calloc");
+        return NULL;
+    }
+
+    for (letter = 'A'; letter <= 'Z'; letter++) {
+        char vol_path[16];
+        HANDLE h;
+        DWORD ret = 0;
+        int attempt;
+        int locked = 0;
+
+        snprintf(vol_path, sizeof(vol_path), "\\\\.\\%c:", letter);
+        h = CreateFileA(vol_path, GENERIC_READ | GENERIC_WRITE,
+                        FILE_SHARE_READ | FILE_SHARE_WRITE, NULL,
+                        OPEN_EXISTING, 0, NULL);
+        if (h == INVALID_HANDLE_VALUE) continue;
+        if (!volume_on_disk(h, disk)) {
+            CloseHandle(h);
+            continue;
+        }
+
+        printf("Locking and dismounting volume %c: ...\n", letter);
+        for (attempt = 0; attempt < 10; attempt++) {
+            if (DeviceIoControl(h, FSCTL_LOCK_VOLUME, NULL, 0, NULL, 0, &ret, NULL)) {
+                locked = 1;
+                break;
+            }
+            Sleep(500);
+        }
+        if (!locked) {
+            fprintf(stderr, "Error: could not lock volume %c: (in use by another program).\n", letter);
+            CloseHandle(h);
+            device_lock_release(lock);
+            return NULL;
+        }
+        DeviceIoControl(h, FSCTL_DISMOUNT_VOLUME, NULL, 0, NULL, 0, &ret, NULL);
+
+        if (exclusive && lock->count < MAX_LOCKED_VOLUMES) {
+            lock->volumes[lock->count++] = h;
+        } else {
+            CloseHandle(h);
+        }
+    }
+    return lock;
+}
+
+void device_lock_release(device_lock_t *lock) {
+    int i;
+    DWORD ret = 0;
+    if (lock == NULL) return;
+    for (i = 0; i < lock->count; i++) {
+        DeviceIoControl(lock->volumes[i], FSCTL_UNLOCK_VOLUME, NULL, 0, NULL, 0, &ret, NULL);
+        CloseHandle(lock->volumes[i]);
+    }
+    free(lock);
+}
+
+#elif defined(__APPLE__)
+
+struct device_lock {
+    int unused;
+};
+
+device_lock_t *device_lock_acquire(const char *dev_path, int exclusive) {
+    char cmd[1024];
+    (void)exclusive;
+
+    printf("Unmounting %s (diskutil)...\n", dev_path);
+    snprintf(cmd, sizeof(cmd), "diskutil unmountDisk '%s'", dev_path);
+    if (system(cmd) != 0) {
+        fprintf(stderr, "Error: failed to unmount %s.\n", dev_path);
+        return NULL;
+    }
+    return (device_lock_t *)calloc(1, sizeof(device_lock_t));
+}
+
+void device_lock_release(device_lock_t *lock) {
+    free(lock);
+}
+
+#elif defined(__linux__)
+
+#include <sys/mount.h>
+
+struct device_lock {
+    int excl_fd;
+};
+
+static int unmount_partitions(const char *dev_path) {
+    FILE *f;
+    char line[1024];
+    char src[512];
+    char mnt[512];
+    size_t devlen = strlen(dev_path);
+    int failures = 0;
+
+    f = fopen("/proc/self/mounts", "r");
+    if (f == NULL) {
+        return 0;
+    }
+    while (fgets(line, sizeof(line), f) != NULL) {
+        if (sscanf(line, "%511s %511s", src, mnt) != 2) continue;
+        if (strncmp(src, dev_path, devlen) != 0) continue;
+        printf("Unmounting %s from %s...\n", src, mnt);
+        if (umount2(mnt, 0) != 0) {
+            fprintf(stderr, "Failed to unmount %s: %s\n", mnt, strerror(errno));
+            failures++;
+        }
+    }
+    fclose(f);
+    return failures == 0 ? 0 : -1;
+}
+
+device_lock_t *device_lock_acquire(const char *dev_path, int exclusive) {
+    device_lock_t *lock = (device_lock_t *)calloc(1, sizeof(*lock));
+    if (lock == NULL) {
+        perror("calloc");
+        return NULL;
+    }
+    lock->excl_fd = -1;
+
+    if (unmount_partitions(dev_path) != 0) {
+        free(lock);
+        return NULL;
+    }
+
+    if (exclusive) {
+        lock->excl_fd = open(dev_path, O_RDONLY | O_EXCL);
+        if (lock->excl_fd < 0) {
+            perror("exclusive open");
+            fprintf(stderr, "Device %s is still in use.\n", dev_path);
+            free(lock);
+            return NULL;
+        }
+    }
+    return lock;
+}
+
+void device_lock_release(device_lock_t *lock) {
+    if (lock == NULL) return;
+    if (lock->excl_fd >= 0) close(lock->excl_fd);
+    free(lock);
+}
+
+#else
+
+struct device_lock {
+    int unused;
+};
+
+device_lock_t *device_lock_acquire(const char *dev_path, int exclusive) {
+    (void)dev_path;
+    (void)exclusive;
+    return (device_lock_t *)calloc(1, sizeof(device_lock_t));
+}
+
+void device_lock_release(device_lock_t *lock) {
+    free(lock);
+}
+
+#endif

--- a/src/core/image_format.c
+++ b/src/core/image_format.c
@@ -1,0 +1,178 @@
+#include "imager/image_format.h"
+
+#include <stdio.h>
+#include <string.h>
+
+#define SECTOR_SIZE      512
+#define ISO_SECTOR_SIZE  2048
+#define VD_FIRST_SECTOR  16
+#define VD_LAST_SECTOR   48
+
+static int read_at(FILE *f, long offset, unsigned char *buf, size_t len) {
+    if (fseek(f, offset, SEEK_SET) != 0) {
+        return -1;
+    }
+    if (fread(buf, 1, len, f) != len) {
+        return -1;
+    }
+    return 0;
+}
+
+static void set_desc(image_info_t *info, const char *desc) {
+    strncpy(info->description, desc, sizeof(info->description) - 1);
+    info->description[sizeof(info->description) - 1] = '\0';
+}
+
+const char *image_format_name(image_format_t fmt) {
+    switch (fmt) {
+        case IMG_FORMAT_ISO_HYBRID:      return "Hybrid ISO (ISO9660 + MBR/GPT)";
+        case IMG_FORMAT_ISO9660:         return "Plain ISO9660 (no partition table)";
+        case IMG_FORMAT_UDF:             return "UDF";
+        case IMG_FORMAT_RAW_MBR:         return "Raw disk image (MBR)";
+        case IMG_FORMAT_RAW_GPT:         return "Raw disk image (GPT)";
+        case IMG_FORMAT_COMPRESSED_GZ:   return "gzip-compressed image (.gz)";
+        case IMG_FORMAT_COMPRESSED_XZ:   return "xz-compressed image (.xz)";
+        case IMG_FORMAT_COMPRESSED_BZ2:  return "bzip2-compressed image (.bz2)";
+        case IMG_FORMAT_COMPRESSED_ZSTD: return "zstd-compressed image (.zst)";
+        case IMG_FORMAT_UNKNOWN:
+        default:                         return "Unknown";
+    }
+}
+
+int image_format_is_raw_writable(const image_info_t *info) {
+    switch (info->format) {
+        case IMG_FORMAT_ISO_HYBRID:
+        case IMG_FORMAT_RAW_MBR:
+        case IMG_FORMAT_RAW_GPT:
+            return 1;
+        case IMG_FORMAT_ISO9660:
+        case IMG_FORMAT_UDF:
+        case IMG_FORMAT_UNKNOWN:
+            return 0;
+        default:
+            return -1;
+    }
+}
+
+static image_format_t detect_compression(const unsigned char *b) {
+    if (b[0] == 0x1F && b[1] == 0x8B) {
+        return IMG_FORMAT_COMPRESSED_GZ;
+    }
+    if (memcmp(b, "\xFD" "7zXZ\x00", 6) == 0) {
+        return IMG_FORMAT_COMPRESSED_XZ;
+    }
+    if (b[0] == 'B' && b[1] == 'Z' && b[2] == 'h') {
+        return IMG_FORMAT_COMPRESSED_BZ2;
+    }
+    if (b[0] == 0x28 && b[1] == 0xB5 && b[2] == 0x2F && b[3] == 0xFD) {
+        return IMG_FORMAT_COMPRESSED_ZSTD;
+    }
+    return IMG_FORMAT_UNKNOWN;
+}
+
+static void extract_volume_label(image_info_t *info, const unsigned char *pvd) {
+    int i;
+    memcpy(info->volume_label, pvd + 40, 32);
+    info->volume_label[32] = '\0';
+    for (i = 31; i >= 0; i--) {
+        if (info->volume_label[i] == ' ' || info->volume_label[i] == '\0') {
+            info->volume_label[i] = '\0';
+        } else {
+            break;
+        }
+    }
+}
+
+int detect_image_format(const char *path, image_info_t *info) {
+    FILE *f;
+    unsigned char sector[ISO_SECTOR_SIZE];
+    image_format_t compressed;
+    int s, i;
+
+    memset(info, 0, sizeof(*info));
+    info->format = IMG_FORMAT_UNKNOWN;
+
+    f = fopen(path, "rb");
+    if (f == NULL) {
+        perror("open image");
+        return -1;
+    }
+
+    if (read_at(f, 0, sector, SECTOR_SIZE) != 0) {
+        fprintf(stderr, "Error: image is smaller than one sector\n");
+        fclose(f);
+        return -1;
+    }
+
+    compressed = detect_compression(sector);
+    if (compressed != IMG_FORMAT_UNKNOWN) {
+        info->format = compressed;
+        set_desc(info, "This is a compressed container, not a raw image. "
+                       "Writing it directly would produce an unusable drive.");
+        fclose(f);
+        return 0;
+    }
+
+    if (sector[510] == 0x55 && sector[511] == 0xAA) {
+        for (i = 0; i < 4; i++) {
+            unsigned char part_type = sector[446 + i * 16 + 4];
+            if (part_type != 0x00) {
+                info->has_mbr = 1;
+                break;
+            }
+        }
+    }
+
+    if (read_at(f, SECTOR_SIZE, sector, SECTOR_SIZE) == 0 &&
+        memcmp(sector, "EFI PART", 8) == 0) {
+        info->has_gpt = 1;
+    }
+
+    for (s = VD_FIRST_SECTOR; s < VD_LAST_SECTOR; s++) {
+        if (read_at(f, (long)s * ISO_SECTOR_SIZE, sector, ISO_SECTOR_SIZE) != 0) {
+            break;
+        }
+        if (memcmp(sector + 1, "CD001", 5) == 0) {
+            info->has_iso9660 = 1;
+            if (sector[0] == 0x01) {
+                extract_volume_label(info, sector);
+            } else if (sector[0] == 0x00 &&
+                       memcmp(sector + 7, "EL TORITO SPECIFICATION", 23) == 0) {
+                info->has_el_torito = 1;
+            }
+        } else if (memcmp(sector + 1, "NSR02", 5) == 0 ||
+                   memcmp(sector + 1, "NSR03", 5) == 0) {
+            info->has_udf = 1;
+        }
+    }
+
+    fclose(f);
+
+    if (info->has_iso9660 && (info->has_mbr || info->has_gpt)) {
+        info->format = IMG_FORMAT_ISO_HYBRID;
+        set_desc(info, "Hybrid ISO with a partition table. Safe to write raw; "
+                       "the drive will boot on BIOS and/or UEFI systems.");
+    } else if (info->has_iso9660) {
+        info->format = IMG_FORMAT_ISO9660;
+        set_desc(info, "Plain ISO9660 image without a partition table. A raw "
+                       "write may not boot on all systems. Windows install "
+                       "ISOs require file extraction instead (not yet supported).");
+    } else if (info->has_udf) {
+        info->format = IMG_FORMAT_UDF;
+        set_desc(info, "UDF image without a partition table (typical of Windows "
+                       "install media). A raw write is unlikely to produce a "
+                       "bootable drive.");
+    } else if (info->has_gpt) {
+        info->format = IMG_FORMAT_RAW_GPT;
+        set_desc(info, "Raw disk image with a GPT partition table. Safe to write raw.");
+    } else if (info->has_mbr) {
+        info->format = IMG_FORMAT_RAW_MBR;
+        set_desc(info, "Raw disk image with an MBR partition table. Safe to write raw.");
+    } else {
+        info->format = IMG_FORMAT_UNKNOWN;
+        set_desc(info, "No recognizable image signature found. The data will be "
+                       "written as-is, but the result may not be bootable.");
+    }
+
+    return 0;
+}

--- a/src/core/image_reader.c
+++ b/src/core/image_reader.c
@@ -1,0 +1,376 @@
+#ifndef _WIN32
+#define _FILE_OFFSET_BITS 64
+#endif
+
+#include "imager/image_reader.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdint.h>
+
+#ifdef HAVE_ZLIB
+#include <zlib.h>
+#endif
+#ifdef HAVE_LZMA
+#include <lzma.h>
+#endif
+#ifdef HAVE_BZIP2
+#include <bzlib.h>
+#endif
+#ifdef HAVE_ZSTD
+#include <zstd.h>
+#endif
+
+#ifdef _WIN32
+#define fseek64 _fseeki64
+#define ftell64 _ftelli64
+#else
+#define fseek64 fseeko
+#define ftell64 ftello
+#endif
+
+#define IN_CHUNK 65536
+
+struct image_reader {
+    FILE *fp;
+    image_format_t format;
+    off_t input_size;
+    off_t input_pos;
+    int input_eof;
+    int stream_end;
+    unsigned char in_buf[IN_CHUNK];
+    size_t in_len;
+    size_t in_off;
+#ifdef HAVE_ZLIB
+    z_stream zs;
+    int zs_init;
+#endif
+#ifdef HAVE_LZMA
+    lzma_stream ls;
+    int ls_init;
+#endif
+#ifdef HAVE_BZIP2
+    bz_stream bs;
+    int bs_init;
+#endif
+#ifdef HAVE_ZSTD
+    ZSTD_DStream *zds;
+    ZSTD_inBuffer zin;
+#endif
+};
+
+int image_reader_format_supported(image_format_t fmt) {
+    switch (fmt) {
+    case IMG_FORMAT_COMPRESSED_GZ:
+#ifdef HAVE_ZLIB
+        return 1;
+#else
+        return 0;
+#endif
+    case IMG_FORMAT_COMPRESSED_XZ:
+#ifdef HAVE_LZMA
+        return 1;
+#else
+        return 0;
+#endif
+    case IMG_FORMAT_COMPRESSED_BZ2:
+#ifdef HAVE_BZIP2
+        return 1;
+#else
+        return 0;
+#endif
+    case IMG_FORMAT_COMPRESSED_ZSTD:
+#ifdef HAVE_ZSTD
+        return 1;
+#else
+        return 0;
+#endif
+    default:
+        return 1;
+    }
+}
+
+static int fill_input(image_reader_t *r) {
+    if (r->in_off < r->in_len) {
+        return 0;
+    }
+    r->in_off = 0;
+    r->in_len = fread(r->in_buf, 1, IN_CHUNK, r->fp);
+    r->input_pos += (off_t)r->in_len;
+    if (r->in_len == 0) {
+        if (ferror(r->fp)) {
+            perror("read image");
+            return -1;
+        }
+        r->input_eof = 1;
+    }
+    return 0;
+}
+
+static long read_raw(image_reader_t *r, unsigned char *out, size_t len) {
+    size_t n = fread(out, 1, len, r->fp);
+    if (n < len && ferror(r->fp)) {
+        perror("read image");
+        return -1;
+    }
+    r->input_pos += (off_t)n;
+    return (long)n;
+}
+
+#ifdef HAVE_ZLIB
+static long read_gzip(image_reader_t *r, unsigned char *out, size_t len) {
+    r->zs.next_out = out;
+    r->zs.avail_out = (uInt)len;
+    while (r->zs.avail_out > 0 && !r->stream_end) {
+        if (r->zs.avail_in == 0 && !r->input_eof) {
+            if (fill_input(r) != 0) return -1;
+            r->zs.next_in = r->in_buf;
+            r->zs.avail_in = (uInt)r->in_len;
+            r->in_off = r->in_len;
+        }
+        int rc = inflate(&r->zs, Z_NO_FLUSH);
+        if (rc == Z_STREAM_END) {
+            r->stream_end = 1;
+            break;
+        }
+        if (rc == Z_BUF_ERROR) {
+            if (r->input_eof) {
+                fprintf(stderr, "gzip stream truncated\n");
+                return -1;
+            }
+            continue;
+        }
+        if (rc != Z_OK) {
+            fprintf(stderr, "gzip decompression error (%d)\n", rc);
+            return -1;
+        }
+        if (r->input_eof && r->zs.avail_in == 0) break;
+    }
+    return (long)(len - r->zs.avail_out);
+}
+#endif
+
+#ifdef HAVE_LZMA
+static long read_xz(image_reader_t *r, unsigned char *out, size_t len) {
+    r->ls.next_out = out;
+    r->ls.avail_out = len;
+    while (r->ls.avail_out > 0 && !r->stream_end) {
+        if (r->ls.avail_in == 0 && !r->input_eof) {
+            if (fill_input(r) != 0) return -1;
+            r->ls.next_in = r->in_buf;
+            r->ls.avail_in = r->in_len;
+            r->in_off = r->in_len;
+        }
+        lzma_ret rc = lzma_code(&r->ls, r->input_eof ? LZMA_FINISH : LZMA_RUN);
+        if (rc == LZMA_STREAM_END) {
+            r->stream_end = 1;
+            break;
+        }
+        if (rc != LZMA_OK) {
+            fprintf(stderr, "xz decompression error (%d)\n", (int)rc);
+            return -1;
+        }
+    }
+    return (long)(len - r->ls.avail_out);
+}
+#endif
+
+#ifdef HAVE_BZIP2
+static long read_bz2(image_reader_t *r, unsigned char *out, size_t len) {
+    r->bs.next_out = (char *)out;
+    r->bs.avail_out = (unsigned int)len;
+    while (r->bs.avail_out > 0 && !r->stream_end) {
+        if (r->bs.avail_in == 0) {
+            if (fill_input(r) != 0) return -1;
+            if (r->in_len == 0) {
+                fprintf(stderr, "bzip2 stream truncated\n");
+                return -1;
+            }
+            r->bs.next_in = (char *)r->in_buf;
+            r->bs.avail_in = (unsigned int)r->in_len;
+            r->in_off = r->in_len;
+        }
+        int rc = BZ2_bzDecompress(&r->bs);
+        if (rc == BZ_STREAM_END) {
+            r->stream_end = 1;
+            break;
+        }
+        if (rc != BZ_OK) {
+            fprintf(stderr, "bzip2 decompression error (%d)\n", rc);
+            return -1;
+        }
+    }
+    return (long)(len - r->bs.avail_out);
+}
+#endif
+
+#ifdef HAVE_ZSTD
+static long read_zstd(image_reader_t *r, unsigned char *out, size_t len) {
+    ZSTD_outBuffer zout;
+    zout.dst = out;
+    zout.size = len;
+    zout.pos = 0;
+    while (zout.pos < zout.size && !r->stream_end) {
+        if (r->zin.pos >= r->zin.size) {
+            if (fill_input(r) != 0) return -1;
+            if (r->in_len == 0) break;
+            r->zin.src = r->in_buf;
+            r->zin.size = r->in_len;
+            r->zin.pos = 0;
+            r->in_off = r->in_len;
+        }
+        size_t rc = ZSTD_decompressStream(r->zds, &zout, &r->zin);
+        if (ZSTD_isError(rc)) {
+            fprintf(stderr, "zstd decompression error: %s\n", ZSTD_getErrorName(rc));
+            return -1;
+        }
+        if (rc == 0 && r->zin.pos >= r->zin.size && r->input_eof) {
+            r->stream_end = 1;
+        }
+    }
+    return (long)zout.pos;
+}
+#endif
+
+static int init_codec(image_reader_t *r, image_format_t format) {
+    (void)r;
+    switch (format) {
+#ifdef HAVE_ZLIB
+    case IMG_FORMAT_COMPRESSED_GZ:
+        if (inflateInit2(&r->zs, 15 + 32) != Z_OK) {
+            fprintf(stderr, "inflateInit2 failed\n");
+            return -1;
+        }
+        r->zs_init = 1;
+        break;
+#endif
+#ifdef HAVE_LZMA
+    case IMG_FORMAT_COMPRESSED_XZ: {
+        lzma_stream init = LZMA_STREAM_INIT;
+        r->ls = init;
+        if (lzma_stream_decoder(&r->ls, UINT64_MAX, LZMA_CONCATENATED) != LZMA_OK) {
+            fprintf(stderr, "lzma_stream_decoder failed\n");
+            return -1;
+        }
+        r->ls_init = 1;
+        break;
+    }
+#endif
+#ifdef HAVE_BZIP2
+    case IMG_FORMAT_COMPRESSED_BZ2:
+        if (BZ2_bzDecompressInit(&r->bs, 0, 0) != BZ_OK) {
+            fprintf(stderr, "BZ2_bzDecompressInit failed\n");
+            return -1;
+        }
+        r->bs_init = 1;
+        break;
+#endif
+#ifdef HAVE_ZSTD
+    case IMG_FORMAT_COMPRESSED_ZSTD:
+        r->zds = ZSTD_createDStream();
+        if (r->zds == NULL) {
+            fprintf(stderr, "ZSTD_createDStream failed\n");
+            return -1;
+        }
+        ZSTD_initDStream(r->zds);
+        break;
+#endif
+    default:
+        break;
+    }
+    return 0;
+}
+
+image_reader_t *image_reader_open(const char *path, image_format_t format) {
+    image_reader_t *r = (image_reader_t *)calloc(1, sizeof(*r));
+    if (r == NULL) {
+        perror("calloc");
+        return NULL;
+    }
+    r->format = format;
+
+    if (!image_reader_format_supported(format)) {
+        fprintf(stderr, "Error: this build has no support for: %s\n",
+                image_format_name(format));
+        free(r);
+        return NULL;
+    }
+
+    r->fp = fopen(path, "rb");
+    if (r->fp == NULL) {
+        perror("open image");
+        free(r);
+        return NULL;
+    }
+
+    if (fseek64(r->fp, 0, SEEK_END) == 0) {
+        r->input_size = (off_t)ftell64(r->fp);
+    }
+    fseek64(r->fp, 0, SEEK_SET);
+
+    if (init_codec(r, format) != 0) {
+        fclose(r->fp);
+        free(r);
+        return NULL;
+    }
+    return r;
+}
+
+long image_reader_read(image_reader_t *r, void *buf, size_t len) {
+    if (len == 0 || r->stream_end) {
+        return 0;
+    }
+    switch (r->format) {
+#ifdef HAVE_ZLIB
+    case IMG_FORMAT_COMPRESSED_GZ:
+        return read_gzip(r, (unsigned char *)buf, len);
+#endif
+#ifdef HAVE_LZMA
+    case IMG_FORMAT_COMPRESSED_XZ:
+        return read_xz(r, (unsigned char *)buf, len);
+#endif
+#ifdef HAVE_BZIP2
+    case IMG_FORMAT_COMPRESSED_BZ2:
+        return read_bz2(r, (unsigned char *)buf, len);
+#endif
+#ifdef HAVE_ZSTD
+    case IMG_FORMAT_COMPRESSED_ZSTD:
+        return read_zstd(r, (unsigned char *)buf, len);
+#endif
+    default:
+        return read_raw(r, (unsigned char *)buf, len);
+    }
+}
+
+off_t image_reader_input_pos(const image_reader_t *r) {
+    return r->input_pos;
+}
+
+off_t image_reader_input_size(const image_reader_t *r) {
+    return r->input_size;
+}
+
+int image_reader_is_compressed(const image_reader_t *r) {
+    return r->format >= IMG_FORMAT_COMPRESSED_GZ;
+}
+
+void image_reader_close(image_reader_t *r) {
+    if (r == NULL) {
+        return;
+    }
+#ifdef HAVE_ZLIB
+    if (r->zs_init) inflateEnd(&r->zs);
+#endif
+#ifdef HAVE_LZMA
+    if (r->ls_init) lzma_end(&r->ls);
+#endif
+#ifdef HAVE_BZIP2
+    if (r->bs_init) BZ2_bzDecompressEnd(&r->bs);
+#endif
+#ifdef HAVE_ZSTD
+    if (r->zds) ZSTD_freeDStream(r->zds);
+#endif
+    if (r->fp) fclose(r->fp);
+    free(r);
+}

--- a/src/core/image_write.c
+++ b/src/core/image_write.c
@@ -1,0 +1,177 @@
+#include "imager/image_write.h"
+#include "imager/image_reader.h"
+#include "imager/iso_operations.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#ifdef _WIN32
+#include <io.h>
+#define dev_write _write
+#define dev_read _read
+#define dev_close _close
+#define dev_flush _commit
+#else
+#include <unistd.h>
+#define dev_write write
+#define dev_read read
+#define dev_close close
+#define dev_flush fsync
+#endif
+
+#define BLOCK 65536
+#define SECTOR 512
+
+int write_image_to_device(const char *image_path, image_format_t format,
+                          const char *dev_path, progress_callback_t cb,
+                          off_t *bytes_written) {
+    image_reader_t *reader = image_reader_open(image_path, format);
+    if (reader == NULL) {
+        return -1;
+    }
+
+    int dev_fd = open_device_file(dev_path, 1);
+    if (dev_fd < 0) {
+        image_reader_close(reader);
+        return -1;
+    }
+
+    unsigned char *buf = (unsigned char *)malloc(BLOCK);
+    if (buf == NULL) {
+        perror("malloc");
+        image_reader_close(reader);
+        dev_close(dev_fd);
+        return -1;
+    }
+
+    printf("\nWriting image to device%s...\n",
+           image_reader_is_compressed(reader) ? " (streaming decompression)" : "");
+
+    off_t written = 0;
+    int ok = 1;
+
+    for (;;) {
+        size_t have = 0;
+        while (have < BLOCK) {
+            long n = image_reader_read(reader, buf + have, BLOCK - have);
+            if (n < 0) {
+                ok = 0;
+                break;
+            }
+            if (n == 0) break;
+            have += (size_t)n;
+        }
+        if (!ok || have == 0) break;
+
+        size_t padded = (have + (SECTOR - 1)) & ~((size_t)SECTOR - 1);
+        if (padded > have) {
+            memset(buf + have, 0, padded - have);
+        }
+        if ((size_t)dev_write(dev_fd, buf, (unsigned int)padded) != padded) {
+            perror("write device");
+            ok = 0;
+            break;
+        }
+        written += (off_t)have;
+        if (cb) cb(image_reader_input_pos(reader), image_reader_input_size(reader), "Writing ");
+        if (have < BLOCK) break;
+    }
+
+    if (ok) {
+        if (cb) cb(image_reader_input_size(reader), image_reader_input_size(reader), "Writing ");
+        dev_flush(dev_fd);
+        printf("\nWrite complete.\n\n");
+        if (bytes_written) *bytes_written = written;
+    } else {
+        fprintf(stderr, "\nWrite failed.\n");
+    }
+
+    free(buf);
+    image_reader_close(reader);
+    dev_close(dev_fd);
+    return ok ? 0 : -1;
+}
+
+int verify_device_against_image(const char *image_path, image_format_t format,
+                                const char *dev_path, off_t total_bytes,
+                                progress_callback_t cb) {
+    image_reader_t *reader = image_reader_open(image_path, format);
+    if (reader == NULL) {
+        return -1;
+    }
+
+    int dev_fd = open_device_file(dev_path, 0);
+    if (dev_fd < 0) {
+        image_reader_close(reader);
+        return -1;
+    }
+
+    unsigned char *src = (unsigned char *)malloc(BLOCK);
+    unsigned char *dst = (unsigned char *)malloc(BLOCK);
+    if (src == NULL || dst == NULL) {
+        perror("malloc");
+        free(src);
+        free(dst);
+        image_reader_close(reader);
+        dev_close(dev_fd);
+        return -1;
+    }
+
+    printf("Verifying written data...\n");
+
+    off_t remaining = total_bytes;
+    int ok = 1;
+
+    while (remaining > 0 && ok) {
+        size_t want = remaining < (off_t)BLOCK ? (size_t)remaining : BLOCK;
+        size_t have = 0;
+        while (have < want) {
+            long n = image_reader_read(reader, src + have, want - have);
+            if (n < 0) {
+                ok = 0;
+                break;
+            }
+            if (n == 0) break;
+            have += (size_t)n;
+        }
+        if (!ok) break;
+        if (have == 0) {
+            fprintf(stderr, "Verification failed: source ended early.\n");
+            ok = 0;
+            break;
+        }
+
+        size_t padded = (have + (SECTOR - 1)) & ~((size_t)SECTOR - 1);
+        size_t got = 0;
+        while (got < padded) {
+            int n = dev_read(dev_fd, dst + got, (unsigned int)(padded - got));
+            if (n <= 0) {
+                fprintf(stderr, "Verification failed: device shorter than image.\n");
+                ok = 0;
+                break;
+            }
+            got += (size_t)n;
+        }
+        if (!ok) break;
+
+        if (memcmp(src, dst, have) != 0) {
+            fprintf(stderr, "Verification failed: data mismatch.\n");
+            ok = 0;
+            break;
+        }
+        remaining -= (off_t)have;
+        if (cb) cb(image_reader_input_pos(reader), image_reader_input_size(reader), "Verifying");
+    }
+
+    if (ok) {
+        if (cb) cb(image_reader_input_size(reader), image_reader_input_size(reader), "Verifying");
+        printf("\nVerification successful!\n");
+    }
+
+    free(src);
+    free(dst);
+    image_reader_close(reader);
+    dev_close(dev_fd);
+    return ok ? 0 : -1;
+}

--- a/src/core/windows_iso.c
+++ b/src/core/windows_iso.c
@@ -1,0 +1,335 @@
+#if !defined(_WIN32)
+#define _DEFAULT_SOURCE
+#define _FILE_OFFSET_BITS 64
+#endif
+
+#include "imager/windows_iso.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdarg.h>
+#include <ctype.h>
+#include <sys/stat.h>
+
+#ifdef _WIN32
+#include <windows.h>
+#include <io.h>
+#define popen _popen
+#define pclose _pclose
+#else
+#include <unistd.h>
+#endif
+
+#define FAT32_MAX_FILE 4294967295ULL
+#define TOTAL_STAGES 6
+
+static void stage(progress_callback_t cb, int n, const char *label) {
+    printf("\n[%d/%d] %s\n", n, TOTAL_STAGES, label);
+    if (cb) cb((off_t)n, (off_t)TOTAL_STAGES, "Extracting");
+}
+
+static int run_cmd(const char *fmt, ...) {
+    char cmd[4096];
+    va_list ap;
+    int rc;
+
+    va_start(ap, fmt);
+    vsnprintf(cmd, sizeof(cmd), fmt, ap);
+    va_end(ap);
+
+    rc = system(cmd);
+    if (rc != 0) {
+        fprintf(stderr, "Command failed (exit %d): %s\n", rc, cmd);
+    }
+    return rc;
+}
+
+#if defined(_WIN32)
+
+static int run_capture(char *out, size_t out_len, const char *fmt, ...) {
+    char cmd[4096];
+    char line[1024];
+    va_list ap;
+    FILE *p;
+
+    va_start(ap, fmt);
+    vsnprintf(cmd, sizeof(cmd), fmt, ap);
+    va_end(ap);
+
+    out[0] = '\0';
+    p = popen(cmd, "r");
+    if (p == NULL) return -1;
+    while (fgets(line, sizeof(line), p) != NULL) {
+        size_t n = strlen(line);
+        while (n > 0 && (line[n - 1] == '\n' || line[n - 1] == '\r' || line[n - 1] == ' ')) {
+            line[--n] = '\0';
+        }
+        if (n > 0) {
+            strncpy(out, line, out_len - 1);
+            out[out_len - 1] = '\0';
+        }
+    }
+    pclose(p);
+    return out[0] != '\0' ? 0 : -1;
+}
+
+int write_iso_extracted(const char *iso_path, const char *dev_path, progress_callback_t cb) {
+    size_t n = strlen(dev_path);
+    size_t d = n;
+    while (d > 0 && isdigit((unsigned char)dev_path[d - 1])) d--;
+    if (d == n || strstr(dev_path, "PhysicalDrive") == NULL) {
+        fprintf(stderr, "Error: extraction mode expects a device like \\\\.\\PhysicalDriveN\n");
+        return -1;
+    }
+    int disk = atoi(dev_path + d);
+
+    char abs_iso[_MAX_PATH];
+    if (_fullpath(abs_iso, iso_path, sizeof(abs_iso)) == NULL) {
+        fprintf(stderr, "Error: cannot resolve path '%s'\n", iso_path);
+        return -1;
+    }
+
+    stage(cb, 1, "Partitioning and formatting target drive (diskpart, FAT32)");
+    char script[_MAX_PATH];
+    if (GetTempPathA((DWORD)sizeof(script), script) == 0) {
+        fprintf(stderr, "GetTempPathA failed\n");
+        return -1;
+    }
+    strncat(script, "imager_diskpart.txt", sizeof(script) - strlen(script) - 1);
+    FILE *sf = fopen(script, "w");
+    if (sf == NULL) {
+        perror("diskpart script");
+        return -1;
+    }
+    fprintf(sf,
+            "select disk %d\n"
+            "clean\n"
+            "convert mbr\n"
+            "create partition primary\n"
+            "active\n"
+            "format fs=fat32 quick label=WINSETUP\n"
+            "assign\n"
+            "exit\n",
+            disk);
+    fclose(sf);
+    if (run_cmd("diskpart /s \"%s\"", script) != 0) {
+        fprintf(stderr, "Note: Windows cannot format FAT32 partitions larger than 32 GB.\n");
+        return -1;
+    }
+
+    stage(cb, 2, "Mounting ISO");
+    char iso_letter[16];
+    char usb_letter[16];
+    if (run_capture(iso_letter, sizeof(iso_letter),
+                    "powershell -NoProfile -Command \"(Mount-DiskImage -ImagePath '%s' -PassThru | Get-Volume).DriveLetter\"",
+                    abs_iso) != 0 || !isalpha((unsigned char)iso_letter[0])) {
+        fprintf(stderr, "Error: failed to mount ISO '%s'\n", abs_iso);
+        return -1;
+    }
+    if (run_capture(usb_letter, sizeof(usb_letter),
+                    "powershell -NoProfile -Command \"(Get-Volume -FileSystemLabel 'WINSETUP' | Select-Object -First 1).DriveLetter\"") != 0
+        || !isalpha((unsigned char)usb_letter[0])) {
+        fprintf(stderr, "Error: could not locate the freshly formatted WINSETUP volume.\n");
+        goto fail;
+    }
+
+    {
+        char wim[_MAX_PATH];
+        struct _stati64 st;
+        int split_wim = 0;
+        snprintf(wim, sizeof(wim), "%c:\\sources\\install.wim", iso_letter[0]);
+        if (_stati64(wim, &st) == 0 && (unsigned long long)st.st_size > FAT32_MAX_FILE) {
+            split_wim = 1;
+        }
+
+        stage(cb, 3, split_wim ? "Copying files (install.wim will be split)" : "Copying files");
+        {
+            char cmd[1024];
+            int rc;
+            snprintf(cmd, sizeof(cmd), "robocopy %c:\\ %c:\\ /E /NFL /NDL /NJH /NJS%s",
+                     iso_letter[0], usb_letter[0], split_wim ? " /XF install.wim" : "");
+            rc = system(cmd);
+            if (rc >= 8) {
+                fprintf(stderr, "robocopy failed (exit %d)\n", rc);
+                goto fail;
+            }
+        }
+
+        if (split_wim) {
+            stage(cb, 4, "Splitting install.wim into FAT32-sized parts (dism)");
+            if (run_cmd("dism /Split-Image /ImageFile:\"%s\" /SWMFile:%c:\\sources\\install.swm /FileSize:3800",
+                        wim, usb_letter[0]) != 0) {
+                goto fail;
+            }
+        } else {
+            stage(cb, 4, "Copy complete");
+        }
+    }
+
+    stage(cb, 5, "Dismounting ISO");
+    run_cmd("powershell -NoProfile -Command \"Dismount-DiskImage -ImagePath '%s' | Out-Null\"", abs_iso);
+    stage(cb, 6, "Done");
+    printf("\nExtraction complete. The drive is bootable on UEFI systems.\n");
+    return 0;
+
+fail:
+    run_cmd("powershell -NoProfile -Command \"Dismount-DiskImage -ImagePath '%s' | Out-Null\"", abs_iso);
+    return -1;
+}
+
+#elif defined(__APPLE__)
+
+static int find_iso_mount(const char *iso_path, char *mnt, size_t len) {
+    char cmd[4096];
+    char line[1024];
+    FILE *p;
+
+    snprintf(cmd, sizeof(cmd), "hdiutil attach -nobrowse -readonly '%s'", iso_path);
+    mnt[0] = '\0';
+    p = popen(cmd, "r");
+    if (p == NULL) return -1;
+    while (fgets(line, sizeof(line), p) != NULL) {
+        char *v = strstr(line, "/Volumes/");
+        if (v != NULL) {
+            size_t n = strlen(v);
+            while (n > 0 && (v[n - 1] == '\n' || v[n - 1] == '\r')) v[--n] = '\0';
+            strncpy(mnt, v, len - 1);
+            mnt[len - 1] = '\0';
+        }
+    }
+    pclose(p);
+    return mnt[0] != '\0' ? 0 : -1;
+}
+
+int write_iso_extracted(const char *iso_path, const char *dev_path, progress_callback_t cb) {
+    char iso_mnt[512];
+    char wim[600];
+    const char *usb_mnt = "/Volumes/WINSETUP";
+    struct stat st;
+    int split_wim = 0;
+    int ret = -1;
+
+    stage(cb, 1, "Attaching ISO");
+    if (find_iso_mount(iso_path, iso_mnt, sizeof(iso_mnt)) != 0) {
+        fprintf(stderr, "Error: failed to attach '%s'\n", iso_path);
+        return -1;
+    }
+
+    stage(cb, 2, "Partitioning and formatting (MBR + FAT32)");
+    if (run_cmd("diskutil partitionDisk '%s' MBR \"MS-DOS FAT32\" WINSETUP R", dev_path) != 0) goto cleanup;
+
+    snprintf(wim, sizeof(wim), "%s/sources/install.wim", iso_mnt);
+    if (stat(wim, &st) == 0 && (unsigned long long)st.st_size > FAT32_MAX_FILE) {
+        if (system("command -v wimlib-imagex >/dev/null 2>&1") != 0) {
+            fprintf(stderr,
+                    "Error: install.wim exceeds 4 GiB and 'wimlib-imagex' is not installed.\n"
+                    "Install it (e.g. 'brew install wimlib') and retry.\n");
+            goto cleanup;
+        }
+        split_wim = 1;
+    }
+
+    stage(cb, 3, split_wim ? "Copying files (install.wim will be split)" : "Copying files");
+    if (split_wim) {
+        if (run_cmd("tar -C '%s' --exclude 'sources/install.wim' -cf - . | tar -C '%s' -xf -", iso_mnt, usb_mnt) != 0) goto cleanup;
+        stage(cb, 4, "Splitting install.wim into FAT32-sized parts");
+        if (run_cmd("mkdir -p '%s/sources' && wimlib-imagex split '%s' '%s/sources/install.swm' 3800", usb_mnt, wim, usb_mnt) != 0) goto cleanup;
+    } else {
+        if (run_cmd("tar -C '%s' -cf - . | tar -C '%s' -xf -", iso_mnt, usb_mnt) != 0) goto cleanup;
+        stage(cb, 4, "Copy complete");
+    }
+
+    stage(cb, 5, "Flushing");
+    run_cmd("sync");
+    ret = 0;
+
+cleanup:
+    stage(cb, 6, "Detaching");
+    run_cmd("diskutil unmountDisk '%s' >/dev/null 2>&1 || true", dev_path);
+    run_cmd("hdiutil detach '%s' >/dev/null 2>&1 || true", iso_mnt);
+    if (ret == 0) {
+        printf("\nExtraction complete. The drive is bootable on UEFI systems.\n");
+    }
+    return ret;
+}
+
+#else
+
+static void partition_node(const char *dev, char *out, size_t len) {
+    size_t n = strlen(dev);
+    if (n > 0 && isdigit((unsigned char)dev[n - 1])) {
+        snprintf(out, len, "%sp1", dev);
+    } else {
+        snprintf(out, len, "%s1", dev);
+    }
+}
+
+int write_iso_extracted(const char *iso_path, const char *dev_path, progress_callback_t cb) {
+    char iso_mnt[] = "/tmp/imager_iso_XXXXXX";
+    char usb_mnt[] = "/tmp/imager_usb_XXXXXX";
+    char part[512];
+    char wim[600];
+    struct stat st;
+    int split_wim = 0;
+    int iso_mounted = 0;
+    int usb_mounted = 0;
+    int ret = -1;
+
+    if (mkdtemp(iso_mnt) == NULL || mkdtemp(usb_mnt) == NULL) {
+        perror("mkdtemp");
+        return -1;
+    }
+
+    stage(cb, 1, "Partitioning target drive (MBR + FAT32)");
+    if (run_cmd("parted -s '%s' mklabel msdos mkpart primary fat32 1MiB 100%% set 1 boot on", dev_path) != 0) goto cleanup;
+    run_cmd("partprobe '%s' 2>/dev/null || true", dev_path);
+    sleep(1);
+    partition_node(dev_path, part, sizeof(part));
+
+    stage(cb, 2, "Formatting FAT32");
+    if (run_cmd("mkfs.vfat -F 32 -n WINSETUP '%s'", part) != 0) goto cleanup;
+
+    stage(cb, 3, "Mounting image and target");
+    if (run_cmd("mount -o loop,ro '%s' '%s'", iso_path, iso_mnt) != 0) goto cleanup;
+    iso_mounted = 1;
+    if (run_cmd("mount '%s' '%s'", part, usb_mnt) != 0) goto cleanup;
+    usb_mounted = 1;
+
+    snprintf(wim, sizeof(wim), "%s/sources/install.wim", iso_mnt);
+    if (stat(wim, &st) == 0 && (unsigned long long)st.st_size > FAT32_MAX_FILE) {
+        if (system("command -v wimlib-imagex >/dev/null 2>&1") != 0) {
+            fprintf(stderr,
+                    "Error: install.wim exceeds 4 GiB and 'wimlib-imagex' is not installed.\n"
+                    "Install wimtools (e.g. 'apt install wimtools') and retry.\n");
+            goto cleanup;
+        }
+        split_wim = 1;
+    }
+
+    stage(cb, 4, split_wim ? "Copying files (install.wim will be split)" : "Copying files");
+    if (split_wim) {
+        if (run_cmd("tar -C '%s' --exclude 'sources/install.wim' -cf - . | tar -C '%s' -xf -", iso_mnt, usb_mnt) != 0) goto cleanup;
+        stage(cb, 5, "Splitting install.wim into FAT32-sized parts");
+        if (run_cmd("mkdir -p '%s/sources' && wimlib-imagex split '%s' '%s/sources/install.swm' 3800", usb_mnt, wim, usb_mnt) != 0) goto cleanup;
+    } else {
+        if (run_cmd("tar -C '%s' -cf - . | tar -C '%s' -xf -", iso_mnt, usb_mnt) != 0) goto cleanup;
+        stage(cb, 5, "Copy complete");
+    }
+
+    stage(cb, 6, "Flushing and unmounting");
+    run_cmd("sync");
+    ret = 0;
+
+cleanup:
+    if (usb_mounted) run_cmd("umount '%s'", usb_mnt);
+    if (iso_mounted) run_cmd("umount '%s'", iso_mnt);
+    rmdir(usb_mnt);
+    rmdir(iso_mnt);
+    if (ret == 0) {
+        printf("\nExtraction complete. The drive is bootable on UEFI systems.\n");
+    }
+    return ret;
+}
+
+#endif

--- a/src/gui_main.cpp
+++ b/src/gui_main.cpp
@@ -8,22 +8,34 @@ extern "C" {
     #include "imager/iso_operations.h"
     #include "imager/progress.h"
     #include "imager/drive_list.h"
+    #include "imager/image_format.h"
+    #include "imager/image_reader.h"
+    #include "imager/image_write.h"
+    #include "imager/windows_iso.h"
+    #include "imager/device_lock.h"
 }
 
 #include <string>
 #include <vector>
 
-// Custom event for progress updates
 wxDEFINE_EVENT(wxEVT_FLASH_PROGRESS, wxThreadEvent);
 wxDEFINE_EVENT(wxEVT_FLASH_COMPLETE, wxThreadEvent);
 wxDEFINE_EVENT(wxEVT_FLASH_ERROR, wxThreadEvent);
 
 class FlashingThread : public wxThread {
 public:
-    FlashingThread(const wxString& isoPath, const wxString& devPath, wxEvtHandler* handler)
-        : wxThread(wxTHREAD_DETACHED), m_isoPath(isoPath), m_devPath(devPath), m_handler(handler) {}
+    FlashingThread(const wxString& isoPath, const wxString& devPath,
+                   image_format_t format, bool extractMode, wxEvtHandler* handler)
+        : wxThread(wxTHREAD_DETACHED), m_isoPath(isoPath), m_devPath(devPath),
+          m_format(format), m_extractMode(extractMode), m_handler(handler) {}
 
 protected:
+    void PostError(const wxString& msg) {
+        wxThreadEvent* event = new wxThreadEvent(wxEVT_FLASH_ERROR);
+        event->SetString(msg);
+        wxQueueEvent(m_handler, event);
+    }
+
     virtual ExitCode Entry() {
         g_currentHandler = m_handler;
 
@@ -37,40 +49,44 @@ protected:
             }
         };
 
-        if (write_iso_to_device(m_isoPath.mb_str(), m_devPath.mb_str(), progress_cb) == 0) {
-            off_t isoSize = 0;
-            int iso_fd = open_iso_file(m_isoPath.mb_str(), &isoSize);
-            if (iso_fd >= 0) {
-                #ifdef _WIN32
-                _close(iso_fd);
-                #else
-                close(iso_fd);
-                #endif
-                
-                if (verify_device_against_iso(m_isoPath.mb_str(), m_devPath.mb_str(), isoSize, progress_cb) == 0) {
-                    wxQueueEvent(m_handler, new wxThreadEvent(wxEVT_FLASH_COMPLETE));
-                } else {
-                    wxThreadEvent* event = new wxThreadEvent(wxEVT_FLASH_ERROR);
-                    event->SetString("Verification Failed");
-                    wxQueueEvent(m_handler, event);
-                }
-            } else {
-                wxThreadEvent* event = new wxThreadEvent(wxEVT_FLASH_ERROR);
-                event->SetString("Failed to open ISO for verification");
-                wxQueueEvent(m_handler, event);
-            }
-        } else {
-            wxThreadEvent* event = new wxThreadEvent(wxEVT_FLASH_ERROR);
-            event->SetString("Flash Failed");
-            wxQueueEvent(m_handler, event);
+        device_lock_t* lock = device_lock_acquire(m_devPath.mb_str(),
+                m_extractMode ? DEVICE_LOCK_UNMOUNT_ONLY : DEVICE_LOCK_EXCLUSIVE);
+        if (lock == NULL) {
+            PostError("Device is busy: could not unmount/lock it.\n"
+                      "Close any programs using the drive and retry.");
+            return (ExitCode)0;
         }
 
+        if (m_extractMode) {
+            if (write_iso_extracted(m_isoPath.mb_str(), m_devPath.mb_str(), progress_cb) == 0) {
+                wxQueueEvent(m_handler, new wxThreadEvent(wxEVT_FLASH_COMPLETE));
+            } else {
+                PostError("Extraction Failed");
+            }
+        } else {
+            off_t bytesWritten = 0;
+            if (write_image_to_device(m_isoPath.mb_str(), m_format, m_devPath.mb_str(),
+                                      progress_cb, &bytesWritten) == 0) {
+                if (verify_device_against_image(m_isoPath.mb_str(), m_format, m_devPath.mb_str(),
+                                                bytesWritten, progress_cb) == 0) {
+                    wxQueueEvent(m_handler, new wxThreadEvent(wxEVT_FLASH_COMPLETE));
+                } else {
+                    PostError("Verification Failed");
+                }
+            } else {
+                PostError("Flash Failed");
+            }
+        }
+
+        device_lock_release(lock);
         return (ExitCode)0;
     }
 
 private:
     wxString m_isoPath;
     wxString m_devPath;
+    image_format_t m_format;
+    bool m_extractMode;
     wxEvtHandler* m_handler;
     static wxEvtHandler* g_currentHandler;
 };
@@ -79,7 +95,7 @@ wxEvtHandler* FlashingThread::g_currentHandler = nullptr;
 
 class MainFrame : public wxFrame {
 public:
-    MainFrame() : wxFrame(NULL, wxID_ANY, "AvdanOS Imager", wxDefaultPosition, wxSize(480, 480)) {
+    MainFrame() : wxFrame(NULL, wxID_ANY, "AvdanOS Imager", wxDefaultPosition, wxSize(480, 560)) {
         SetBackgroundColour(wxSystemSettings::GetColour(wxSYS_COLOUR_FRAMEBK));
 
         wxBoxSizer* mainSizer = new wxBoxSizer(wxVERTICAL);
@@ -108,7 +124,16 @@ public:
         isoSizer->Add(m_isoText, 1, wxEXPAND | wxRIGHT, 5);
         m_selectBtn = new wxButton(this, wxID_ANY, "SELECT");
         isoSizer->Add(m_selectBtn, 0);
-        driveSizer->Add(isoSizer, 0, wxEXPAND | wxLEFT | wxRIGHT | wxBOTTOM, 10);
+        driveSizer->Add(isoSizer, 0, wxEXPAND | wxLEFT | wxRIGHT, 10);
+
+        m_formatLabel = new wxStaticText(this, wxID_ANY, "Format: (no image selected)");
+        driveSizer->Add(m_formatLabel, 0, wxLEFT | wxRIGHT | wxTOP, 10);
+
+        m_extractCheck = new wxCheckBox(this, wxID_ANY, "Windows extraction mode (FAT32 + file copy)");
+        m_extractCheck->SetToolTip("For Windows-style install ISOs: partitions the drive,\n"
+                                   "formats FAT32, copies files and splits install.wim\n"
+                                   "when it exceeds the FAT32 4 GiB limit.");
+        driveSizer->Add(m_extractCheck, 0, wxLEFT | wxRIGHT | wxTOP | wxBOTTOM, 10);
 
         mainSizer->Add(driveSizer, 0, wxEXPAND | wxALL, 15);
 
@@ -164,6 +189,31 @@ private:
         else m_devChoice->Append("No suitable drives found");
     }
 
+    void AnalyzeImage() {
+        m_imgValid = false;
+        m_formatLabel->SetLabel("Format: (no image selected)");
+        if (m_isoText->GetValue().IsEmpty()) return;
+
+        if (detect_image_format(m_isoText->GetValue().mb_str(), &m_imgInfo) != 0) {
+            m_formatLabel->SetLabel("Format: could not analyze file");
+            m_extractCheck->Enable(false);
+            m_extractCheck->SetValue(false);
+            return;
+        }
+        m_imgValid = true;
+
+        wxString info = wxString::Format("Format: %s", image_format_name(m_imgInfo.format));
+        if (m_imgInfo.volume_label[0] != '\0') {
+            info += wxString::Format("  |  Label: %s", wxString::FromUTF8(m_imgInfo.volume_label));
+        }
+        m_formatLabel->SetLabel(info);
+
+        bool compressed = (image_format_is_raw_writable(&m_imgInfo) < 0);
+        m_extractCheck->Enable(!compressed);
+        m_extractCheck->SetValue(!compressed && m_imgInfo.format == IMG_FORMAT_UDF);
+        Layout();
+    }
+
     void OnToggleUsbOnly(wxCommandEvent& event) {
         RefreshDrives();
     }
@@ -173,32 +223,62 @@ private:
     }
 
     void OnSelectISO(wxCommandEvent& event) {
-        wxFileDialog openFileDialog(this, _("Open ISO file"), "", "",
-                                   "ISO files (*.iso)|*.iso|All files (*.*)|*.*", wxFD_OPEN|wxFD_FILE_MUST_EXIST);
+        wxFileDialog openFileDialog(this, _("Open disk image"), "", "",
+                                   "Disk images (*.iso;*.img;*.gz;*.xz;*.bz2;*.zst)|*.iso;*.img;*.gz;*.xz;*.bz2;*.zst|All files (*.*)|*.*",
+                                   wxFD_OPEN|wxFD_FILE_MUST_EXIST);
         if (openFileDialog.ShowModal() == wxID_CANCEL) return;
         m_isoText->SetValue(openFileDialog.GetPath());
+        AnalyzeImage();
     }
 
     void OnStartFlash(wxCommandEvent& event) {
         if (m_isoText->GetValue().IsEmpty() || m_devChoice->GetSelection() == wxNOT_FOUND || m_drivePaths.empty()) {
-            wxMessageBox("Please select both an ISO file and a target device.", "Error", wxOK | wxICON_ERROR);
+            wxMessageBox("Please select both an image file and a target device.", "Error", wxOK | wxICON_ERROR);
             return;
+        }
+        if (!m_imgValid) {
+            wxMessageBox("The selected image could not be analyzed.", "Error", wxOK | wxICON_ERROR);
+            return;
+        }
+
+        bool extractMode = m_extractCheck->GetValue();
+        int writable = image_format_is_raw_writable(&m_imgInfo);
+
+        if (writable < 0) {
+            if (!image_reader_format_supported(m_imgInfo.format)) {
+                wxMessageBox(wxString::Format(
+                        "This build has no %s support compiled in.\n"
+                        "Decompress the file manually or rebuild with the codec library.",
+                        image_format_name(m_imgInfo.format)),
+                    "Error", wxOK | wxICON_ERROR);
+                return;
+            }
         }
 
         wxString devPath = m_drivePaths[m_devChoice->GetSelection()];
 
-        int answer = wxMessageBox("This will ERASE ALL DATA on " + devPath + ". Continue?", 
-                                 "WARNING", wxYES_NO | wxICON_WARNING | wxNO_DEFAULT);
+        wxString warning = "This will ERASE ALL DATA on " + devPath + ".";
+        if (!extractMode && writable == 0) {
+            warning += "\n\nWarning: " + wxString::FromUTF8(m_imgInfo.description);
+            if (m_imgInfo.format == IMG_FORMAT_UDF || m_imgInfo.format == IMG_FORMAT_ISO9660) {
+                warning += "\nTip: enable 'Windows extraction mode' for Windows install ISOs.";
+            }
+        }
+        warning += "\n\nContinue?";
+
+        int answer = wxMessageBox(warning, "WARNING", wxYES_NO | wxICON_WARNING | wxNO_DEFAULT);
         if (answer != wxYES) return;
 
         m_startBtn->Disable();
         m_selectBtn->Disable();
         m_refreshBtn->Disable();
         m_devChoice->Disable();
+        m_extractCheck->Disable();
         m_gauge->SetValue(0);
         m_statusLabel->SetLabel("Initializing...");
 
-        FlashingThread* thread = new FlashingThread(m_isoText->GetValue(), devPath, this);
+        FlashingThread* thread = new FlashingThread(m_isoText->GetValue(), devPath,
+                                                    m_imgInfo.format, extractMode, this);
         if (thread->Run() != wxTHREAD_NO_ERROR) {
             wxMessageBox("Could not create the flashing thread!", "Error", wxOK | wxICON_ERROR);
             ResetUI();
@@ -214,7 +294,7 @@ private:
     void OnComplete(wxThreadEvent& event) {
         m_gauge->SetValue(100);
         m_statusLabel->SetLabel("Flash Successful!");
-        wxMessageBox("The ISO has been successfully written and verified.", "Success", wxOK | wxICON_INFORMATION);
+        wxMessageBox("The image has been successfully written to the device.", "Success", wxOK | wxICON_INFORMATION);
         ResetUI();
     }
 
@@ -229,17 +309,23 @@ private:
         m_selectBtn->Enable();
         m_refreshBtn->Enable();
         m_devChoice->Enable();
+        bool compressed = m_imgValid && (image_format_is_raw_writable(&m_imgInfo) < 0);
+        m_extractCheck->Enable(m_imgValid && !compressed);
     }
 
     wxTextCtrl* m_isoText;
     wxChoice* m_devChoice;
     wxCheckBox* m_listUsbOnly;
+    wxCheckBox* m_extractCheck;
     wxButton* m_selectBtn;
     wxButton* m_refreshBtn;
     wxButton* m_startBtn;
     wxGauge* m_gauge;
     wxStaticText* m_statusLabel;
+    wxStaticText* m_formatLabel;
     std::vector<wxString> m_drivePaths;
+    image_info_t m_imgInfo;
+    bool m_imgValid = false;
 };
 
 class ImagerApp : public wxApp {

--- a/src/main.c
+++ b/src/main.c
@@ -9,6 +9,7 @@
 #include "imager/image_reader.h"
 #include "imager/image_write.h"
 #include "imager/windows_iso.h"
+#include "imager/device_lock.h"
 
 static void extra_usage(void) {
     printf("\nOptions:\n");
@@ -96,27 +97,41 @@ int main(int argc, char *argv[]) {
         return 1;
     }
 
+    device_lock_t *lock = device_lock_acquire(dev_path,
+            extract_mode ? DEVICE_LOCK_UNMOUNT_ONLY : DEVICE_LOCK_EXCLUSIVE);
+    if (lock == NULL) {
+        fprintf(stderr, "Error: could not unmount/lock device '%s'.\n"
+                        "Close any programs using the drive and retry.\n", dev_path);
+        return 1;
+    }
+
     if (extract_mode) {
         if (write_iso_extracted(iso_path, dev_path, print_progress_cli) != 0) {
             fprintf(stderr, "Error: extraction to '%s' failed\n", dev_path);
+            device_lock_release(lock);
             return 1;
         }
         printf("\n=== Imaging Complete! ===\n");
         printf("Files from '%s' were extracted to '%s'.\n", iso_path, dev_path);
         printf("(File-level copy: bit-for-bit verification is not applicable.)\n\n");
+        device_lock_release(lock);
         return 0;
     }
 
     off_t bytes_written = 0;
     if (write_image_to_device(iso_path, img_info.format, dev_path, print_progress_cli, &bytes_written) != 0) {
         fprintf(stderr, "Error: Failed to write image to device '%s'\n", dev_path);
+        device_lock_release(lock);
         return 1;
     }
 
     if (verify_device_against_image(iso_path, img_info.format, dev_path, bytes_written, print_progress_cli) != 0) {
         fprintf(stderr, "Error: Verification failed for device '%s'\n", dev_path);
+        device_lock_release(lock);
         return 1;
     }
+
+    device_lock_release(lock);
 
     printf("\n=== Imaging Complete! ===\n");
     printf("Image '%s' has been successfully written to device '%s'\n", iso_path, dev_path);

--- a/src/main.c
+++ b/src/main.c
@@ -2,60 +2,124 @@
 #include <stdlib.h>
 #include <string.h>
 
-#ifdef _WIN32
-#include <io.h>
-#define close _close
-#else
-#include <unistd.h>
-#endif
-
 #include <sys/types.h>
 #include "imager/utils.h"
 #include "imager/iso_operations.h"
+#include "imager/image_format.h"
+#include "imager/image_reader.h"
+#include "imager/image_write.h"
+#include "imager/windows_iso.h"
+
+static void extra_usage(void) {
+    printf("\nOptions:\n");
+    printf("  --extract   File-extraction mode for Windows-style install ISOs:\n");
+    printf("              partitions the drive (MBR), formats FAT32, copies files,\n");
+    printf("              and splits install.wim when it exceeds the FAT32 limit.\n");
+    printf("\nCompressed images (.gz, .xz, .bz2, .zst) are decompressed on the fly\n");
+    printf("when the matching codec is compiled in.\n");
+}
 
 int main(int argc, char *argv[]) {
-    if (argc != 3) {
-        if (argc == 2 && (strcmp(argv[1], "-h") == 0 || strcmp(argv[1], "--help") == 0)) {
+    int extract_mode = 0;
+    const char *iso_path = NULL;
+    const char *dev_path = NULL;
+
+    for (int i = 1; i < argc; i++) {
+        if (strcmp(argv[i], "-h") == 0 || strcmp(argv[i], "--help") == 0) {
             usage(argv[0]);
+            extra_usage();
             return 0;
+        } else if (strcmp(argv[i], "--extract") == 0) {
+            extract_mode = 1;
+        } else if (iso_path == NULL) {
+            iso_path = argv[i];
+        } else if (dev_path == NULL) {
+            dev_path = argv[i];
+        } else {
+            basic_usage(argv[0]);
+            return 1;
         }
+    }
+
+    if (iso_path == NULL || dev_path == NULL) {
         basic_usage(argv[0]);
+        extra_usage();
 #ifdef _WIN32
         printf("\nNote for Windows users: Device path should look like \\\\.\\PhysicalDriveX\n");
         printf("You can find the drive number in Disk Management or using 'wmic diskdrive list brief'\n");
 #endif
         return 1;
     }
-    
-    const char *iso_path = argv[1];
-    const char *dev_path = argv[2];
+
+    printf("Image: %s\n", iso_path);
+
+    image_info_t img_info;
+    if (detect_image_format(iso_path, &img_info) != 0) {
+        fprintf(stderr, "Error: Failed to analyze image file '%s'\n", iso_path);
+        return 1;
+    }
+
+    printf("Detected format: %s\n", image_format_name(img_info.format));
+    if (img_info.volume_label[0] != '\0') {
+        printf("Volume label:    %s\n", img_info.volume_label);
+    }
+    if (img_info.has_el_torito) {
+        printf("Bootable:        yes (El Torito)\n");
+    }
+
+    int writable = image_format_is_raw_writable(&img_info);
+
+    if (extract_mode) {
+        if (writable < 0) {
+            fprintf(stderr, "\nError: extraction mode cannot operate on compressed images.\n"
+                            "Decompress the file first, then retry with --extract.\n");
+            return 1;
+        }
+        printf("Mode:            file extraction (Windows-style install media)\n");
+    } else if (writable == 0) {
+        printf("\nWarning: %s\n", img_info.description);
+        if (img_info.format == IMG_FORMAT_UDF || img_info.format == IMG_FORMAT_ISO9660) {
+            printf("Hint: for Windows install ISOs, rerun with --extract to copy files\n"
+                   "onto a bootable FAT32 partition instead of raw writing.\n");
+        }
+    } else if (writable < 0) {
+        if (!image_reader_format_supported(img_info.format)) {
+            fprintf(stderr, "\nError: this build has no %s support compiled in.\n",
+                    image_format_name(img_info.format));
+            fprintf(stderr, "Rebuild with the codec library installed, or decompress the file manually.\n");
+            return 1;
+        }
+        printf("\nCompressed image detected: streaming decompression will be used.\n");
+    }
 
     if (!confirm_destructive_action(dev_path)) {
         return 1;
     }
 
-    printf("ISO: %s\n", iso_path);
-
-    off_t iso_size;
-    int temp_fd = open_iso_file(iso_path, &iso_size);
-    if (temp_fd < 0) {
-        fprintf(stderr, "Error: Failed to open ISO file '%s'\n", iso_path);
-        return 1;
-    }
-    close(temp_fd);
-
-    if (write_iso_to_device(iso_path, dev_path, print_progress_cli) != 0) {
-        fprintf(stderr, "Error: Failed to write ISO to device '%s'\n", dev_path);
-        return 1;
+    if (extract_mode) {
+        if (write_iso_extracted(iso_path, dev_path, print_progress_cli) != 0) {
+            fprintf(stderr, "Error: extraction to '%s' failed\n", dev_path);
+            return 1;
+        }
+        printf("\n=== Imaging Complete! ===\n");
+        printf("Files from '%s' were extracted to '%s'.\n", iso_path, dev_path);
+        printf("(File-level copy: bit-for-bit verification is not applicable.)\n\n");
+        return 0;
     }
 
-    if (verify_device_against_iso(iso_path, dev_path, iso_size, print_progress_cli) != 0) {
+    off_t bytes_written = 0;
+    if (write_image_to_device(iso_path, img_info.format, dev_path, print_progress_cli, &bytes_written) != 0) {
+        fprintf(stderr, "Error: Failed to write image to device '%s'\n", dev_path);
+        return 1;
+    }
+
+    if (verify_device_against_image(iso_path, img_info.format, dev_path, bytes_written, print_progress_cli) != 0) {
         fprintf(stderr, "Error: Verification failed for device '%s'\n", dev_path);
         return 1;
     }
 
     printf("\n=== Imaging Complete! ===\n");
-    printf("ISO '%s' has been successfully written to device '%s'\n", iso_path, dev_path);
+    printf("Image '%s' has been successfully written to device '%s'\n", iso_path, dev_path);
     printf("The device is now ready for use.\n\n");
 
     return 0;


### PR DESCRIPTION
This sure is a big one. It takes the imager from "dd with a progress bar" to something
that can handle basically any image you throw at it, on all three platforms. It
also fixes the most dangerous gap there was, which was writing to a drive while the OS still
had filesystems mounted on it.

## The imager now knows what it's flashing

New format detection module (`src/core/image_format.c`, no dependencies). It reads
the magic bytes and volume descriptors and figures out whether you gave it a hybrid
ISO, a plain ISO9660, a UDF image (i.e. Windows install media), a raw MBR/GPT disk
image, or a compressed container. It also pulls out the volume label and checks for
an El Torito boot record. Both the CLI and the GUI show all of this *before* the
"this will erase everything" prompt, so you know what you're about to write and
whether it will actually boot.

## Compressed images flash directly

`foo.iso.gz`, `bar.img.xz`, `.bz2`, `.zst` - all of them now write straight to the
device, decompressed on the fly. No temp files, no manual unpacking.

The codecs are optional. CMake picks up whichever of zlib / liblzma / bzip2 / zstd
are installed; if one is missing, the imager still builds and just tells the user to
decompress that kind of file manually. The Makefile has `CODEC_DEFS` / `CODEC_LIBS`
knobs for the same thing.

Two details worth knowing: tail writes are padded to 512-byte sectors because raw
devices on Windows refuse unaligned writes, and verification re-streams the source
for a proper bit-for-bit compare. Progress is measured against the compressed input,
so the bar stays honest even though we don't know the decompressed size upfront.

## The device gets unmounted and locked before we write

New `device_lock` module, acquired right after you confirm and held until
verification finishes:

- Linux: unmounts every mounted partition (parsed from `/proc/self/mounts`), then
  takes the kernel's exclusive block-device claim via `O_EXCL`. Nothing can remount
  or open the device mid-write.
- Windows: finds every volume on the physical drive, locks it (`FSCTL_LOCK_VOLUME`,
  retried for a few seconds) and dismounts it, keeping the handles open through
  write + verify. This kills the classic Windows failure mode where a raw write
  silently loses to the filesystem cache.
- macOS: `diskutil unmountDisk`.

Raw writes hold the exclusive claim the whole time. Extraction mode only unmounts,
because its tooling needs to partition and mount the drive itself. If something is
still using the drive, you get a "close any programs using the drive" error instead
of a corrupted stick.

## Windows install ISOs actually work now (--extract)

Writing a Windows ISO raw gives you a stick that won't boot - they're not hybrid
images. The new `--extract` mode does what Rufus does instead: partitions the drive
(MBR), formats FAT32, copies the ISO contents file by file, and splits
`install.wim` into `.swm` parts when it's over the FAT32 4 GiB limit.

Under the hood it drives the standard platform tools: diskpart + PowerShell +
robocopy + dism on Windows, parted + mkfs.vfat + loop mount + tar (+ wimlib) on
Linux, hdiutil + diskutil + tar (+ wimlib) on macOS. Both frontends suggest
`--extract` when they detect Windows-style media.

## GUI parity

`imager-gui` now does everything the CLI does. The file picker accepts compressed
images, the detected format and volume label show up as soon as you pick a file,
the flashing thread runs the streaming write/verify pipeline with proper device
locking, and there's a "Windows extraction mode" checkbox that pre-selects itself
when it sees a Windows ISO (and greys out for compressed images). The erase
confirmation now includes format-specific boot warnings instead of a generic one.

## Docs

README, CONTRIBUTING, BUILD.md and USAGE.md were all rewritten to match reality:
what the tool does today, per-distro build dependencies, how to test destructive
changes against loop devices instead of your own SSD, what every warning means,
and a troubleshooting section that covers busy devices, missing codecs and
counterfeit USB sticks. The old GUI docs described a drag-and-drop flow that
never existed; that's gone.

## Known limitations

- Extraction mode shells out to platform tooling. A native FAT32/UDF
  implementation could replace that eventually, but this works today.
- Windows can't format FAT32 partitions bigger than 32 GB (diskpart limitation).
- Extracted media boots via UEFI only; no legacy BIOS bootsector yet.
